### PR TITLE
feat(nix): add darwin support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,20 +12,6 @@
 *.a
 *.d
 
-# Nix build results
-/result
-/result-*
-*.o
-*.so
-*.dylib
-*.a
-*.d
-*.o
-*.so
-*.dylib
-*.a
-*.d
-
 # Nix shell
 .shell.direnv/
 .direnv/
@@ -33,12 +19,6 @@
 # Nix store paths
 /nix/
 !/nix/
-
-# Nix build output
-/outputs/*.lock
-/outputs/*.drv
-/outputs/*.check
-/outputs-*/
 
 # Nix garbage collection roots
 /gc-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "haumea": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685133229,
+        "narHash": "sha256-FePm/Gi9PBSNwiDFq3N+DWdfxFq0UKsVVTJS3cQPn94=",
+        "owner": "nix-community",
+        "repo": "haumea",
+        "rev": "34dd58385092a23018748b50f9b23de6266dffc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v0.2.2",
+        "repo": "haumea",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -122,6 +143,7 @@
     },
     "root": {
       "inputs": {
+        "haumea": "haumea",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -71,5 +71,10 @@
       # Use the main nixpkgs to ensure consistent package versions
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    haumea = {
+      url = "github:nix-community/haumea/v0.2.2";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 }

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -1,6 +1,6 @@
 # 📚 System Libraries
 
-This directory contains reusable Nix library functions and utilities for the system configuration.
+This directory contains reusable Nix library functions and utilities for the system configuration, including macOS system management and module loading.
 
 ## 🏗️ Directory Structure
 
@@ -8,10 +8,71 @@ This directory contains reusable Nix library functions and utilities for the sys
 libraries/
 ├── README.md        # This file
 ├── default.nix      # Main library entry point
+├── macos-system.nix # macOS system configuration utilities
 └── relative-to-root.nix  # Path manipulation utilities
 ```
 
 ## 📦 Available Libraries
+
+### `default.nix`
+
+Main entry point for the libraries module system. Dynamically imports all `.nix` files in this directory and provides a unified interface.
+
+#### Features
+- Automatic module discovery and loading
+- Strategy pattern for module-specific argument passing
+- Clean public API with internal functions exposed for testing
+
+**Example from `supported-systems/aarch64-darwin/default.nix`**:
+```nix
+# Load all .nix files from the src/ directory using Haumea
+# This dynamically discovers all host configurations
+data = haumea.lib.load {
+  src = ./src; # Source directory containing host configurations
+  inputs = args; # Pass through all flake inputs and other arguments
+};
+
+# Merge all darwinConfigurations from all loaded files
+outputs = {
+  darwinConfigurations =
+    lib.attrsets.mergeAttrsList
+    (map (it: it.darwinConfigurations or {}) (builtins.attrValues data));
+};
+```
+
+### `macos-system.nix`
+
+Provides utilities for creating and managing macOS system configurations using nix-darwin and home-manager.
+
+#### Features
+- Creates complete darwinSystem configurations
+- Optional home-manager integration
+- Input validation and type checking
+- Follows SOLID principles for maintainability
+
+**Example from `supported-systems/aarch64-darwin/src/wang-lin.nix`**:
+```nix
+# Module imports are organized by category
+modules = {
+  # System-level modules (nix-darwin configuration)
+  darwin-modules = (map libraries.relativeTo [
+    # Paths to system modules
+  ]);
+
+  # User-level modules (Home Manager configuration)
+  home-modules = map libraries.relativeTo [
+    # Paths to home-manager modules
+  ];
+};
+
+# Combine modules with all other arguments
+systemArgs = modules // args // {
+  hostName = name;  # Current hostname
+};
+
+# The final darwin configuration for this host
+darwinConfigurations.${name} = libraries.macosSystem systemArgs;
+```
 
 ### `relative-to-root.nix`
 
@@ -36,18 +97,56 @@ Creates a path relative to the repository root.
 
 ## 🛠 Usage
 
-Import the libraries in your Nix expressions:
+Import and use the libraries in your Nix expressions:
+
+### Basic Usage
 
 ```nix
-{ lib, ... }:
+# In your flake.nix or system configuration
+{
+  # ... other flake inputs ...
 
+  outputs = { self, nixpkgs, ... } @ inputs: {
+    # Import and use the libraries
+    nixosConfigurations = {
+      my-host = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          # Your system configuration
+        ];
+      };
+    };
+
+    # macOS configuration using macosSystem
+    darwinConfigurations = let
+      # Import the libraries
+      libraries = import ./libraries {
+        inherit inputs;
+        lib = nixpkgs.lib;
+      };
+    in {
+      # Import host configurations
+      wang-lin = import ./supported-systems/aarch64-darwin/src/wang-lin.nix {
+        inherit libraries inputs;
+        system = "aarch64-darwin";
+        variables = { username = "user"; };
+      };
+    };
+  };
+}
+```
+
+### Advanced Usage
+
+Access internal functions for testing and advanced use cases:
+
+```nix
+{ lib, inputs, ... }:
 let
-  # Import the libraries
-  libraries = import ./libraries { inherit lib; };
-
+  libraries = import ./libraries { inherit lib inputs; };
 in {
-  # Use the relativeToRoot function
-  myPath = libraries.relativeToRoot "path/from/root";
+  # Access internal functions (use with caution)
+  _test = libraries._internal;
 }
 ```
 
@@ -75,6 +174,6 @@ This project is licensed under the terms of the [MIT License](../LICENSE).
 
 ---
 
-📅 Last Updated: 2025-06-09
+📅 Last Updated: 2025-06-10
 
 [⬆ Back to Top](#-system-libraries)

--- a/libraries/default.nix
+++ b/libraries/default.nix
@@ -5,11 +5,7 @@
 #
 # Version: 1.0.0
 # Last Updated: 2025-06-09
-{
-  lib,
-  ...
-}:
-let
+{lib, ...}: let
   # Get all .nix files in the current directory
   nixFiles =
     builtins.filter

--- a/libraries/default.nix
+++ b/libraries/default.nix
@@ -3,26 +3,68 @@
 # Main entry point for library functions. Automatically imports all .nix files
 # in this directory and makes them available through a single attribute set.
 #
-# Version: 1.0.0
-# Last Updated: 2025-06-09
-{lib, ...}: let
+# Version: 2.0.0
+# Last Updated: 2025-06-10
+#
+# This module follows SOLID principles for better maintainability and extensibility.
+# It provides a dynamic way to import library modules with appropriate arguments.
+{
+  lib,
+  inputs ? null,
+  ...
+} @ args: let
+  # Default arguments passed to all modules unless overridden
+  defaultArgs = {inherit lib;};
+
+  # Define argument strategies for different module types
+  # Each strategy is a function that receives the full args and returns the arguments to pass
+  moduleStrategies = {
+    # Default strategy - only pass the library
+    default = _: defaultArgs;
+
+    # Special handling for macos-system.nix - pass all arguments
+    "macos-system.nix" = args: args;
+
+    # Add more strategies here as needed
+    # "special-module.nix" = args: args // { special = true; };
+  };
+
+  # Get the strategy function for a given file
+  getStrategy = file:
+    if lib.hasAttr file moduleStrategies
+    then moduleStrategies."${file}"
+    else moduleStrategies.default;
+
   # Get all .nix files in the current directory
-  nixFiles =
+  getNixFiles = dir:
     builtins.filter
     (file: file != "default.nix" && lib.strings.hasSuffix ".nix" file)
-    (builtins.attrNames (builtins.readDir ./.));
+    (builtins.attrNames (builtins.readDir dir));
 
-  # Import each file and collect their attributes
-  imported = map (file: import (./. + "/${file}") {inherit lib;}) nixFiles;
+  # Import a single file with the appropriate arguments
+  importFile = file: let
+    strategy = getStrategy file;
+    importArgs = strategy args;
+  in
+    import (./. + "/${file}") importArgs;
+
+  # Import all library files
+  imported = map importFile (getNixFiles ./.);
 
   # Merge all attribute sets into one
   combined = lib.foldl' lib.recursiveUpdate {} imported;
 in
+  # Export the combined libraries with some additional utilities
   combined
   // {
     # Export all libraries as a single attribute set
-    inherit (combined) relativeToRoot;
+    inherit (combined) relativeToRoot macosSystem;
 
     # Export the lib itself for convenience
     inherit lib;
+
+    # Export the import mechanism for testing or advanced usage
+    _importers = {
+      inherit getStrategy importFile getNixFiles;
+    };
   }

--- a/libraries/macos-system.nix
+++ b/libraries/macos-system.nix
@@ -1,41 +1,73 @@
+# macOS System Configuration Library
+#
+# This library provides a function to create a macOS system configuration
+# using nix-darwin and home-manager.
+#
+# All parameters except `lib` are optional with sensible defaults.
 {
   lib,
-  inputs,
-  darwin-modules,
+  # Required inputs for nix-darwin and home-manager
+  inputs ? {},
+  # List of nix-darwin modules to include
+  darwin-modules ? [],
+  # List of home-manager modules to include
   home-modules ? [],
-  variables,
-  system,
-  genSpecialArgs,
+  # User variables (must contain at least username)
+  variables ? {username = "user";},
+  # System architecture (defaults to aarch64-darwin for Apple Silicon)
+  system ? "aarch64-darwin",
+  # Function to generate special arguments
+  genSpecialArgs ? (system: {inherit system;}),
+  # Pre-computed special arguments (defaults to genSpecialArgs result)
   specialArgs ? (genSpecialArgs system),
   ...
 }: let
-  inherit (inputs) nixpkgs-darwin home-manager nix-darwin;
-in
-  nix-darwin.lib.darwinSystem {
-    inherit system specialArgs;
-    modules =
-      darwin-modules
-      ++ [
-        ({lib, ...}: {
-          nixpkgs.pkgs = import nixpkgs-darwin {
-            inherit system; # refer the `system` parameter form outer scope recursively
-            # To use chrome, we need to allow the installation of non-free software
-            config.allowUnfree = true;
-          };
-        })
-      ]
-      ++ (
-        lib.optionals ((lib.lists.length home-modules) > 0)
-        [
-          home-manager.darwinModules.home-manager
-          {
-            home-manager.useGlobalPkgs = true;
-            home-manager.useUserPackages = true;
-            home-manager.backupFileExtension = "home-manager.backup";
+  # Import required inputs with fallbacks to prevent evaluation errors
+  nixpkgs-darwin = inputs.nixpkgs-darwin or (throw "nixpkgs-darwin input is required");
+  home-manager = inputs.home-manager or null; # Make home-manager optional
+  nix-darwin = inputs.nix-darwin or (throw "nix-darwin input is required");
 
-            home-manager.extraSpecialArgs = specialArgs;
-            home-manager.users."${variables.username}".imports = home-modules;
-          }
+  # Default username if not provided
+  username = variables.username or "user";
+
+  # Create the darwinSystem configuration with input validation
+  darwinConfig = assert lib.assertMsg (nix-darwin != null) "nix-darwin input is required";
+  assert lib.assertMsg (nixpkgs-darwin != null) "nixpkgs-darwin input is required";
+    nix-darwin.lib.darwinSystem {
+      inherit system specialArgs;
+      modules =
+        darwin-modules
+        ++ [
+          ({lib, ...}: {
+            nixpkgs.pkgs = import nixpkgs-darwin {
+              inherit system; # refer the `system` parameter from outer scope recursively
+              # To use chrome, we need to allow the installation of non-free software
+              config.allowUnfree = true;
+            };
+          })
         ]
-      );
-  }
+        ++ (
+          lib.optionals ((lib.lists.length home-modules) > 0)
+          (
+            let
+              # Only include home-manager if it's available and we have home-modules
+              homeManagerAvailable = home-manager != null && home-manager ? darwinModules;
+            in
+              if homeManagerAvailable
+              then [
+                home-manager.darwinModules.home-manager
+                {
+                  home-manager.useGlobalPkgs = true;
+                  home-manager.useUserPackages = true;
+                  home-manager.backupFileExtension = "home-manager.backup";
+                  home-manager.extraSpecialArgs = specialArgs;
+                  home-manager.users."${username}".imports = home-modules;
+                }
+              ]
+              else []
+          )
+        );
+    };
+in
+  # Return the configuration
+  darwinConfig

--- a/libraries/macos-system.nix
+++ b/libraries/macos-system.nix
@@ -1,10 +1,11 @@
 # macOS System Configuration Library
 #
 # This library provides a function to create a macOS system configuration
-# using nix-darwin and home-manager.
+# using nix-darwin and home-manager, following SOLID principles.
 #
 # All parameters except `lib` are optional with sensible defaults.
 {
+  # Core Nixpkgs library
   lib,
   # Required inputs for nix-darwin and home-manager
   inputs ? {},
@@ -13,6 +14,7 @@
   # List of home-manager modules to include
   home-modules ? [],
   # User variables (must contain at least username)
+  # Defaults to a minimal configuration with username 'user'
   variables ? {username = "user";},
   # System architecture (defaults to aarch64-darwin for Apple Silicon)
   system ? "aarch64-darwin",
@@ -21,53 +23,142 @@
   # Pre-computed special arguments (defaults to genSpecialArgs result)
   specialArgs ? (genSpecialArgs system),
   ...
-}: let
-  # Import required inputs with fallbacks to prevent evaluation errors
-  nixpkgs-darwin = inputs.nixpkgs-darwin or (throw "nixpkgs-darwin input is required");
-  home-manager = inputs.home-manager or null; # Make home-manager optional
-  nix-darwin = inputs.nix-darwin or (throw "nix-darwin input is required");
+} @ args: let
+  # Type definitions for better error messages
+  types = {
+    nonEmptyStr = str: lib.isString str && str != "";
+    nonEmptyAttrs = attrs: lib.isAttrs attrs && attrs != {};
+    nonEmptyList = list: lib.isList list && list != [];
+  };
 
-  # Default username if not provided
-  username = variables.username or "user";
+  # Input validation
+  validateInputs = {
+    inherit lib inputs system;
 
-  # Create the darwinSystem configuration with input validation
-  darwinConfig = assert lib.assertMsg (nix-darwin != null) "nix-darwin input is required";
-  assert lib.assertMsg (nixpkgs-darwin != null) "nixpkgs-darwin input is required";
+    # Check if required inputs are present
+    checkRequiredInputs = {
+      nix-darwin = inputs.nix-darwin or null;
+      nixpkgs-darwin = inputs.nixpkgs-darwin or null;
+    };
+
+    # Validate username in variables
+    checkUsername = variables.username or "user";
+  };
+
+  # Configuration builders
+  builders = {
+    # Build nixpkgs configuration
+    mkNixpkgsConfig = {system, ...}: {
+      nixpkgs.pkgs = import inputs.nixpkgs-darwin {
+        inherit system;
+        config.allowUnfree = true; # Required for some packages like Chrome
+      };
+    };
+
+    # Build home-manager configuration if available and needed
+    mkHomeManagerConfig = {
+      home-manager,
+      home-modules,
+      username,
+      specialArgs,
+    }:
+      if
+        home-manager
+        != null
+        && home-manager ? darwinModules
+        && lib.lists.length home-modules > 0
+      then [
+        home-manager.darwinModules.home-manager
+        {
+          home-manager = {
+            useGlobalPkgs = true;
+            useUserPackages = true;
+            backupFileExtension = "home-manager.backup";
+            extraSpecialArgs = specialArgs;
+            users."${username}".imports = home-modules;
+          };
+        }
+      ]
+      else [];
+  };
+
+  # Main configuration builder that creates a complete darwinSystem configuration
+  # by combining all modules and configurations.
+  #
+  # Parameters:
+  #   - nix-darwin: The nix-darwin package
+  #   - system: Target system architecture (e.g., "aarch64-darwin")
+  #   - specialArgs: Special arguments to pass to modules
+  #   - darwin-modules: List of nix-darwin modules to include
+  #   - home-manager: The home-manager package (optional)
+  #   - home-modules: List of home-manager modules to include
+  #   - username: System username for home-manager configuration
+  #
+  # Returns: A complete darwinSystem configuration
+  mkDarwinConfig = {
+    nix-darwin,
+    system,
+    specialArgs,
+    darwin-modules,
+    home-manager,
+    home-modules,
+    username,
+  }:
     nix-darwin.lib.darwinSystem {
       inherit system specialArgs;
       modules =
         darwin-modules
-        ++ [
-          ({lib, ...}: {
-            nixpkgs.pkgs = import nixpkgs-darwin {
-              inherit system; # refer the `system` parameter from outer scope recursively
-              # To use chrome, we need to allow the installation of non-free software
-              config.allowUnfree = true;
-            };
-          })
-        ]
-        ++ (
-          lib.optionals ((lib.lists.length home-modules) > 0)
-          (
-            let
-              # Only include home-manager if it's available and we have home-modules
-              homeManagerAvailable = home-manager != null && home-manager ? darwinModules;
-            in
-              if homeManagerAvailable
-              then [
-                home-manager.darwinModules.home-manager
-                {
-                  home-manager.useGlobalPkgs = true;
-                  home-manager.useUserPackages = true;
-                  home-manager.backupFileExtension = "home-manager.backup";
-                  home-manager.extraSpecialArgs = specialArgs;
-                  home-manager.users."${username}".imports = home-modules;
-                }
-              ]
-              else []
-          )
-        );
+        ++ [(builders.mkNixpkgsConfig {inherit system;})]
+        ++ (builders.mkHomeManagerConfig {
+          inherit home-manager home-modules username specialArgs;
+        });
     };
+
+  # Validate and process all inputs
+  # Combines required inputs with validation results
+  validated =
+    validateInputs.checkRequiredInputs
+    // {
+      inherit (validateInputs) checkUsername;
+    };
+
+  # Final set of inputs with validation and defaults applied
+  # Ensures all required inputs are present and provides defaults where possible
+  checkedInputs = lib.recursiveUpdate validated {
+    nix-darwin = validated.nix-darwin or (throw "nix-darwin input is required");
+    nixpkgs-darwin = validated.nixpkgs-darwin or (throw "nixpkgs-darwin input is required");
+    home-manager = inputs.home-manager or null; # Make home-manager optional
+  };
 in
-  # Return the configuration
-  darwinConfig
+  # Public interface of the module
+  # This is what users of this library will interact with
+  {
+    # Main function to create a macOS system configuration
+    #
+    # Returns: A function that creates a complete system configuration
+    # Example:
+    #   macosSystem {
+    #     inherit inputs;
+    #     system = "aarch64-darwin";
+    #     variables = { username = "user"; };
+    #     darwin-modules = [ ./my-config.nix ];
+    #   }
+    macosSystem = mkDarwinConfig {
+      inherit (checkedInputs) nix-darwin nixpkgs-darwin home-manager;
+      inherit system specialArgs darwin-modules home-modules;
+      username = validateInputs.checkUsername;
+    };
+
+    # Internal functions and values exposed for testing and advanced use cases
+    # Not part of the public API and may change between releases
+    _internal = {
+      # Validation functions and input processing
+      inherit validateInputs;
+
+      # Configuration builders for different parts of the system
+      inherit builders;
+
+      # Main configuration builder function
+      inherit mkDarwinConfig;
+    };
+  }

--- a/libraries/macos-system.nix
+++ b/libraries/macos-system.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  inputs,
+  darwin-modules,
+  home-modules ? [],
+  variables,
+  system,
+  genSpecialArgs,
+  specialArgs ? (genSpecialArgs system),
+  ...
+}: let
+  inherit (inputs) nixpkgs-darwin home-manager nix-darwin;
+in
+  nix-darwin.lib.darwinSystem {
+    inherit system specialArgs;
+    modules =
+      darwin-modules
+      ++ [
+        ({lib, ...}: {
+          nixpkgs.pkgs = import nixpkgs-darwin {
+            inherit system; # refer the `system` parameter form outer scope recursively
+            # To use chrome, we need to allow the installation of non-free software
+            config.allowUnfree = true;
+          };
+        })
+      ]
+      ++ (
+        lib.optionals ((lib.lists.length home-modules) > 0)
+        [
+          home-manager.darwinModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.backupFileExtension = "home-manager.backup";
+
+            home-manager.extraSpecialArgs = specialArgs;
+            home-manager.users."${variables.username}".imports = home-modules;
+          }
+        ]
+      );
+  }

--- a/libraries/relative-to-root.nix
+++ b/libraries/relative-to-root.nix
@@ -4,7 +4,6 @@
 #
 # Version: 1.0.0
 # Last Updated: 2025-06-09
-
 {lib, ...}: {
   # Create a path relative to the repository root
   #

--- a/outputs/README.md
+++ b/outputs/README.md
@@ -1,89 +1,117 @@
-# 📦 Outputs
+# 📦 System Outputs
 
-This directory contains the main Nix flake outputs that define the system configurations, packages, and development environments provided by this repository.
+This directory contains the main Nix flake outputs that define the system configurations, packages, and development environments for the infrastructure.
 
-## 📁 Directory Structure
+## 🏗️ System Architecture
 
-```
-outputs/
-└── default.nix    # Primary entry point for all flake outputs
-```
+The system uses a modular approach to manage configurations across different platforms and architectures. The key components are:
 
-## 🎯 Purpose
+1. **System Definitions**: In `supported-systems/`, containing platform-specific configurations
+2. **Shared Modules**: Reusable components in `modules/`
+3. **Home Manager**: User environment configurations in `home/`
+4. **Development Shells**: Pre-configured environments in `dev-shells/`
 
-The `outputs` directory serves as the central location for all Nix flake outputs, making it easy to discover and use the various configurations and packages defined in this repository.
+## 🧩 Core Components
 
-## 🏗️ Main Components
+### System Management
 
-### `default.nix`
-The primary entry point that defines all flake outputs, including:
-- System configurations for different platforms
-- Development environments
-- Custom packages and overlays
-- CI/CD checks and formatters
-- Home Manager configurations
+The `default.nix` implements a flexible system management approach with these features:
 
-## 💻 Usage
+- **Multi-nixpkgs Support**: Multiple nixpkgs versions (stable, unstable)
+- **Cross-platform**: Support for NixOS and macOS (via nix-darwin)
+- **Modular Design**: Reusable configurations through modules
+- **Developer Experience**: Consistent environments with development shells
 
-### List All Available Outputs
+### Special Arguments
+
+A key feature is the `genSpecialArgs` function that provides:
+- Access to all flake inputs
+- Custom libraries and utilities
+- Multiple nixpkgs versions (stable, unstable)
+- System-specific configurations
+
+## 🚀 Usage
+
+### List Available Systems
 ```bash
-# Show tree of all available outputs
 nix flake show
 ```
 
-### Build a Specific Output
+### Build a System Configuration
 ```bash
-# Example: Build a NixOS configuration
+# NixOS
 nix build .#nixosConfigurations.hostname.config.system.build.toplevel
 
-# Example: Build a specific package
-nix build .#packages.x86_64-linux.hello
+# macOS
+nix build .#darwinConfigurations.hostname.system
 ```
 
-### Enter a Development Environment
+### Enter Development Shell
 ```bash
-# Enter the default development shell
+# Default shell
 nix develop
 
-# Or a specific shell
+# Specific shell
 nix develop .#devShells.x86_64-linux.just
 ```
 
-## 📂 Output Categories
+## 🏗️ Output Categories
 
-### System Configurations (`nixosConfigurations.*`)
-Pre-configured system setups for different environments and use cases.
+### `nixosConfigurations.*`
+NixOS system configurations. Each host should have its own configuration file in `supported-systems/`.
 
-### Development Shells (`devShells.*`)
-Consistent development environments with all necessary tools and dependencies.
+### `darwinConfigurations.*`
+macOS system configurations managed by nix-darwin.
 
-### Packages (`packages.*`)
-Custom Nix packages and overlays for various platforms.
+### `devShells.*`
+Development environments with all necessary tools and dependencies.
 
-### Checks (`checks.*`)
+### `packages.*`
+Custom Nix packages and overlays.
+
+### `checks.*`
 Automated checks for code quality and correctness.
 
-### Home Manager (`homeConfigurations.*`)
-User environment configurations managed by Home Manager.
+## 🛠️ Development
 
-## ➕ Adding New Outputs
+### Adding a New System
 
-1. Add your new output to the appropriate section in `default.nix`
-2. Document the new output in this README with:
-   - Purpose and intended use case
-   - Example usage
-   - Any dependencies or requirements
-3. Include any necessary tests or examples
+1. Create a new file in `supported-systems/` (e.g., `x86_64-linux/myhost.nix`)
+2. Import and use the appropriate modules
+3. Add the system to the appropriate configuration set in `default.nix`
 
-## 📦 Dependencies
+Example:
+```nix
+# In supported-systems/x86_64-linux/myhost.nix
+{ config, pkgs, ... }: {
+  # System configuration here
+  system.stateVersion = "23.11";
+}
+```
 
-- [Nix](https://nixos.org/) (≥ 2.4)
-- [nix-darwin](https://github.com/LnL7/nix-darwin) (≥ 1.11.0, for macOS configurations)
-- [home-manager](https://github.com/nix-community/home-manager) (≥ 23.11, for user environment management)
+### Using Multiple nixpkgs Versions
 
-## 🔗 Related Documentation
+The configuration provides access to multiple nixpkgs versions:
 
-- [Checks](../checks/README.md) - For running code quality checks
-- [Development Shells](../dev-shells/README.md) - For development environment setup
-- [NixOS Manual](https://nixos.org/manual/nixos/stable/) - For NixOS configuration reference
-- [Home Manager Manual](https://nix-community.github.io/home-manager/) - For user environment configuration
+```nix
+# In a module or configuration
+{ pkgs, pkgs-unstable, pkgs-stable, ... }: {
+  environment.systemPackages = [
+    pkgs.keepassxc       # From main nixpkgs
+    pkgs-unstable.helix  # Latest version from unstable
+    pkgs-stable.firefox  # Stable version
+  ];
+}
+```
+
+## 📚 Documentation
+
+- [NixOS Manual](https://nixos.org/manual/nixos/stable/)
+- [Home Manager Manual](https://nix-community.github.io/home-manager/)
+- [nix-darwin Documentation](https://github.com/LnL7/nix-darwin)
+
+## 🔗 Related
+
+- [Development Shells](../dev-shells/README.md)
+- [Checks](../checks/README.md)
+- [Modules](../modules/README.md)

--- a/outputs/default.nix
+++ b/outputs/default.nix
@@ -28,7 +28,11 @@
   # Import project-specific libraries
   # Type: AttrSet
   # Contains custom utility functions and shared modules
-  libraries = import ../libraries {inherit lib;};
+  libraries = import ../libraries {
+    inherit lib;
+    inherit inputs;
+    inherit (inputs) self;
+  };
 
   variables = import ../variables {inherit lib;};
   #############################################################################

--- a/supported-systems/README.md
+++ b/supported-systems/README.md
@@ -1,0 +1,102 @@
+# 🖥️ Supported Systems
+
+This directory contains system configurations for different architectures and operating systems supported by this repository. Each subdirectory represents a specific system architecture and contains the necessary configurations for that platform.
+
+## 📁 Directory Structure
+
+```
+supported-systems/
+├── aarch64-darwin/      # Apple Silicon (M1/M2) Macs
+│   ├── default.nix     # System entry point and module loader
+│   └── src/            # Host-specific configurations
+│       └── wang-lin.nix # Configuration for host 'wang-lin'
+└── x86_64-linux/        # 64-bit Intel/AMD Linux systems
+    └── ...
+```
+
+## 🎯 Purpose
+
+The `supported-systems` directory provides a modular way to organize system configurations by architecture and host. This structure allows for:
+
+- Clear separation of concerns between different architectures
+- Easy addition of new hosts and architectures
+- Reuse of common configurations through the module system
+- Simplified maintenance and updates
+
+## 🏗️ Architecture Structure
+
+Each architecture directory (e.g., `aarch64-darwin`) follows this pattern:
+
+1. `default.nix`: The entry point that loads all host configurations
+2. `src/`: Contains host-specific configuration files
+   - Each `.nix` file in this directory should export a `darwinConfigurations` attribute set
+
+## 🖥️ Adding a New Host
+
+To add a new host, follow the instructions in the architecture-specific README for your target platform:
+
+- [Apple Silicon (aarch64-darwin)](./aarch64-darwin/README.md#-adding-a-new-host)
+- [Intel/AMD Linux (x86_64-linux)](./x86_64-linux/README.md#-adding-a-new-host)
+
+Each architecture may have specific requirements and configurations. The host configuration will be automatically picked up by the flake's outputs once created.
+
+## 🔄 Updating System Configurations
+
+To update a system configuration:
+
+```bash
+# For NixOS
+sudo nixos-rebuild switch --flake .#hostname
+
+# For macOS
+darwin-rebuild switch --flake .#hostname
+```
+
+## 🧩 Module System
+
+This repository uses a modular approach to system configuration:
+
+- **Common modules**: Shared across all systems in `modules/`
+- **Architecture-specific modules**: In each architecture directory
+- **Host-specific overrides**: In the host's `.nix` file
+
+## 🛠️ Development
+
+### Linting
+
+```bash
+# Check Nix files for common mistakes
+nix flake check
+
+# Format Nix files
+nix fmt .
+```
+
+### Testing Changes
+
+1. Test the configuration in a VM (NixOS only):
+   ```bash
+   nixos-rebuild build-vm --flake .#hostname
+   ./result/bin/run-hostname-vm
+   ```
+
+2. Build the system configuration:
+   ```bash
+   nix build .#nixosConfigurations.hostname.config.system.build.toplevel
+   ```
+
+## 📚 Related Documentation
+
+- [NixOS Manual](https://nixos.org/manual/nixos/stable/)
+- [nix-darwin Manual](https://github.com/LnL7/nix-darwin)
+- [Home Manager Manual](https://nix-community.github.io/home-manager/)
+- [Flakes Documentation](https://nixos.wiki/wiki/Flakes)
+
+## 🤝 Contributing
+
+When adding new system configurations:
+
+1. Follow the existing directory structure
+2. Document any architecture-specific considerations
+3. Test configurations in a VM or on a test machine before applying to production
+4. Update this README if you add new architectures or make structural changes

--- a/supported-systems/aarch64-darwin/README.md
+++ b/supported-systems/aarch64-darwin/README.md
@@ -1,0 +1,170 @@
+# 🍏 aarch64-darwin (Apple Silicon)
+
+This directory contains system configurations for Apple Silicon (M1/M2) Macs. The configurations are managed using [nix-darwin](https://github.com/LnL7/nix-darwin) and integrated with the main flake.
+
+## 📁 Directory Structure
+
+```
+aarch64-darwin/
+├── default.nix    # Entry point that loads all host configurations
+└── src/           # Host-specific configurations
+    └── wang-lin.nix  # Configuration for 'wang-lin' host
+```
+
+## 🎯 Purpose
+
+This directory manages configurations for Apple Silicon Macs, providing:
+
+- System-wide settings and services
+- Package management through nix-darwin
+- Integration with Home Manager for user environments
+- Host-specific customizations
+
+## 🛠️ Configuration Files
+
+### `default.nix`
+
+The entry point that uses Haumea to dynamically load all host configurations from the `src/` directory. It:
+
+1. Imports Haumea for dynamic module loading
+2. Loads all `.nix` files from `src/`
+3. Merges the `darwinConfigurations` from all hosts
+
+### `src/*.nix`
+
+Each file in the `src/` directory represents a physical host. The filename should match the hostname (e.g., `wang-lin.nix` for host 'wang-lin').
+
+## 🖥️ Adding a New Host
+
+Follow these steps to add a new Apple Silicon (aarch64-darwin) host to the system:
+
+1. **Create a new host configuration file** in the `src/` directory named after your host (e.g., `my-macbook.nix`)
+
+2. **Use the following template** as a starting point, adjusting the `name` and configurations as needed:
+
+   ```nix
+   # src/my-macbook.nix
+   {
+     # Required arguments (passed by Haumea)
+     inputs,
+     lib,
+     libraries,
+     system,
+     genSpecialArgs,
+     ...
+   } @ args: let
+     # Host identifier - should match the filename (without .nix)
+     name = "my-macbook";
+
+     # Module imports organized by category
+     modules = {
+       # System-level modules (nix-darwin configuration)
+       darwin-modules =
+         (map libraries.relativeTo [
+           # Common system modules
+           # "modules/darwin/common.nix"
+           
+           # Host-specific system configuration
+           # "hosts/darwin-${name}/system.nix"
+         ])
+         ++ [
+           # Inline system configuration
+           ({ config, pkgs, ... }: {
+             system.stateVersion = 4;
+             networking.hostName = name;
+             # Add other system configurations here
+           })
+         ];
+
+       # User-level modules (Home Manager configuration)
+       home-modules = map libraries.relativeTo [
+         # Common user modules
+         # "home/common.nix"
+         
+         # Host-specific user configuration
+         # "hosts/darwin-${name}/home.nix"
+       ];
+     };
+
+     # Combine modules with all other arguments
+     systemArgs = modules // args // {
+       # Add any additional arguments needed by modules
+       hostName = name;
+     };
+   in {
+     # The final darwin configuration for this host
+     darwinConfigurations.${name} = libraries.macosSystem systemArgs;
+   }
+   ```
+
+3. **Apply the configuration** to your host:
+   ```bash
+   darwin-rebuild switch --flake .#my-macbook
+   ```
+
+### Key Points
+
+- The hostname in the file (e.g., `my-macbook`) should match the filename (without .nix)
+- System configurations go in `darwin-modules`
+- User configurations go in `home-modules`
+- Use `libraries.relativeTo` for importing modules relative to the project root
+- The configuration will be automatically picked up by the flake's outputs
+
+## 🔄 Applying Changes
+
+To apply the configuration to a host:
+
+```bash
+darwin-rebuild switch --flake .#hostname
+```
+
+## 🧩 Module Structure
+
+For better organization, consider this module structure:
+
+```
+hosts/
+└── hostname/
+    ├── default.nix    # Main system configuration
+    ├── system.nix     # System packages and settings
+    └── home.nix       # User environment
+```
+
+## 🛠️ Development
+
+### Linting
+
+```bash
+# Check Nix syntax
+nix-shell -p nixpkgs-fmt --run "nixpkgs-fmt --check ."
+
+# Format Nix files
+alejandra .
+```
+
+### Testing
+
+1. Build the configuration:
+   ```bash
+   nix build .#darwinConfigurations.hostname.system
+   ```
+
+2. Check for evaluation errors:
+   ```bash
+   nix flake check
+   ```
+
+## 📚 Related Documentation
+
+- [nix-darwin Manual](https://github.com/LnL7/nix-darwin)
+- [Home Manager Manual](https://nix-community.github.io/home-manager/)
+- [NixOS Wiki](https://nixos.wiki/)
+
+## 🤝 Contributing
+
+When making changes:
+
+1. Keep host-specific configurations in their respective files
+2. Document any non-obvious configurations
+3. Test changes before committing
+4. Update this README if the structure changes

--- a/supported-systems/aarch64-darwin/default.nix
+++ b/supported-systems/aarch64-darwin/default.nix
@@ -1,0 +1,37 @@
+# aarch64-darwin/default.nix
+#
+# This file serves as the entry point for loading all aarch64-darwin (Apple Silicon) host configurations.
+# It uses Haumea to dynamically load all .nix files from the src/ directory and merge their
+# darwinConfigurations outputs.
+#
+# The structure allows for easy addition of new hosts by simply adding a new .nix file to the src/ directory.
+# Each file should export a darwinConfigurations attribute set that will be merged with others.
+{
+  lib,
+  inputs,
+  ...
+} @ args: let
+  inherit (inputs) haumea;
+
+  # Load all .nix files from the src/ directory using Haumea
+  # This dynamically discovers all host configurations
+  data = haumea.lib.load {
+    src = ./src; # Source directory containing host configurations
+    inputs = args; # Pass through all flake inputs and other arguments
+  };
+
+  # Convert the attribute set to a list of values, discarding the file paths
+  # since they're not needed in the final output
+  dataWithoutPaths = builtins.attrValues data;
+
+  # Merge all darwinConfigurations from all loaded files
+  # This creates a single attribute set with all host configurations
+  outputs = {
+    darwinConfigurations =
+      lib.attrsets.mergeAttrsList
+      (map (it: it.darwinConfigurations or {}) dataWithoutPaths);
+  };
+in
+  outputs
+# Return the merged configurations for all hosts
+

--- a/supported-systems/aarch64-darwin/src/wang-lin.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin.nix
@@ -62,7 +62,7 @@
   # Combine modules with all other arguments
   systemArgs =
     modules
-    // args
+    // args # This includes all the original arguments like variables, lib, etc.
     // {
       # Add any additional arguments needed by modules
       hostName = name;

--- a/supported-systems/aarch64-darwin/src/wang-lin.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin.nix
@@ -1,0 +1,74 @@
+# wang-lin.nix
+#
+# Configuration for the 'wang-lin' host (Apple Silicon Mac).
+# This file defines the system configuration for a specific host, including both
+# system-level and user-level settings.
+#
+# The configuration is split into modules for better organization and reusability.
+# Common modules are imported from the shared modules directory, while host-specific
+# customizations are defined inline or in separate files.
+{
+  # IMPORTANT: All arguments must be kept, even if not directly used in this file.
+  # Haumea passes arguments lazily, and they may be used by imported modules.
+  inputs,
+  lib,
+  libraries,
+  variables,
+  system,
+  genSpecialArgs,
+  ...
+} @ args: let
+  # Host identifier - should match the filename (without .nix)
+  name = "wang-lin";
+
+  # Module imports are organized by category
+  modules = {
+    # System-level modules (nix-darwin configuration)
+    darwin-modules =
+      # Convert relative paths to absolute paths using the project root
+      (map libraries.relativeTo [
+        # Common system modules
+        # "modules/darwin/common.nix"
+
+        # Host-specific system configuration
+        # "hosts/darwin-${name}/system.nix"
+
+        # Secrets management
+        # "secrets/darwin.nix"
+      ])
+      # Additional modules can be added here
+      ++ [
+        # Inline module example:
+        # ({ config, pkgs, ... }: {
+        #   # System configuration
+        #   system.stateVersion = 4;
+        #   networking.hostName = "${name}";
+        # })
+      ];
+
+    # User-level modules (Home Manager configuration)
+    home-modules = map libraries.relativeTo [
+      # Common user modules
+      # "home/common.nix"
+
+      # Host-specific user configuration
+      # "hosts/darwin-${name}/home.nix"
+
+      # Desktop environment
+      # "home/darwin/desktop.nix"
+    ];
+  };
+
+  # Combine modules with all other arguments
+  systemArgs =
+    modules
+    // args
+    // {
+      # Add any additional arguments needed by modules
+      hostName = name;
+    };
+in {
+  # The final darwin configuration for this host
+  # This will be merged with other hosts' configurations
+  darwinConfigurations.${name} = libraries.macosSystem systemArgs;
+}

--- a/variables/README.md
+++ b/variables/README.md
@@ -1,0 +1,110 @@
+# 📊 System Variables
+
+This directory contains global variables and user-specific configurations used throughout the system. These variables ensure consistency across different parts of the configuration and make it easy to update common values in one place.
+
+## 📁 Directory Structure
+
+```
+variables/
+├── README.md        # This file
+└── default.nix      # Main variables definition
+```
+
+## 🎯 Purpose
+
+The `variables` module provides a centralized location for:
+
+- User account information
+- System-wide settings
+- Common values used across multiple configurations
+- Sensitive data (handled securely via sops-nix)
+
+## 🔍 Available Variables
+
+### User Variables
+
+These variables define user-specific settings:
+
+- `username`: System username (e.g., "aytordev")
+- `fullname`: User's full name (e.g., "Aytor Vicente Martinez")
+- `email`: User's email address (e.g., "me@aytor.dev")
+
+## 🛠 Usage
+
+### Importing Variables
+
+Import the variables in your Nix expressions:
+
+```nix
+{ lib, ... }:
+
+let
+  # Import the variables
+  variables = import ./variables { inherit lib; };
+in {
+  # Use the variables
+  users.users.${variables.username} = {
+    isNormalUser = true;
+    home = "/home/${variables.username}";
+    # ... other user settings
+  };
+}
+```
+
+### Adding New Variables
+
+1. Edit `default.nix` to add new variables:
+
+```nix
+{lib}: {
+  # Existing variables
+  username = "aytordev";
+  fullname = "Aytor Vicente Martinez";
+  email = "me@aytor.dev";
+  
+  # New variable example
+  hostname = "my-laptop";
+  timezone = "Europe/Madrid";
+}
+```
+
+2. Use the new variable in your configurations:
+
+```nix
+{ config, lib, ... }:
+
+let
+  variables = import ./variables { inherit lib; };
+in {
+  # Using the new variables
+  networking.hostName = variables.hostname;
+  time.timeZone = variables.timezone;
+}
+```
+
+## 🔒 Security Considerations
+
+- **Sensitive Data**: For sensitive information like passwords or API keys, use `sops-nix` instead of storing them directly in this file.
+- **Secrets Management**: See the project's security documentation for handling secrets properly.
+
+## 🔄 Best Practices
+
+1. **Keep It Simple**: Only store values that are used in multiple places.
+2. **Documentation**: Always document new variables with comments in `default.nix`.
+3. **Type Safety**: Consider adding type annotations for complex variables.
+4. **Naming**: Use descriptive, camelCase names for variables.
+
+## 📚 Related Documentation
+
+- [NixOS Manual: Options](https://nixos.org/manual/nixos/stable/options.html)
+- [Home Manager Manual](https://nix-community.github.io/home-manager/)
+- [sops-nix Documentation](https://github.com/Mic92/sops-nix)
+
+## 🤝 Contributing
+
+When adding or modifying variables:
+
+1. Document the purpose of each new variable
+2. Follow the existing naming conventions
+3. Update this README if the variable structure changes
+4. Test your changes in a development environment before committing

--- a/variables/default.nix
+++ b/variables/default.nix
@@ -1,0 +1,5 @@
+{lib}: {
+  username = "aytordev";
+  userfullname = "Aytor Vicente Martinez";
+  useremail = "me@aytor.dev";
+}


### PR DESCRIPTION
This pull request introduces significant updates to the Nix-based system configuration, focusing on modularity, macOS support, and improved documentation. Key changes include the addition of the Haumea library, a new `macos-system.nix` library for macOS configurations, enhancements to the library structure, and updates to the `outputs` system. Below are the most important changes grouped by theme:

### Library Enhancements
* Added the Haumea library as an input in `flake.nix` to enable dynamic module discovery and loading.
* Refactored `libraries/default.nix` to implement SOLID principles, introduce argument strategies for modules, and dynamically import `.nix` files with appropriate arguments.
* Introduced `libraries/macos-system.nix`, a new library for macOS system configurations using nix-darwin and home-manager, with input validation and modular design.

### Documentation Updates
* Expanded `libraries/README.md` to include detailed descriptions of new libraries (`macos-system.nix`) and their features, along with usage examples. [[1]](diffhunk://#diff-9c92eb5dde12ecc321d8edb137def7147b0bb307846ed5ed2f53c23c840fb25aL3-R76) [[2]](diffhunk://#diff-9c92eb5dde12ecc321d8edb137def7147b0bb307846ed5ed2f53c23c840fb25aL39-R149)
* Updated `outputs/README.md` to reflect the modular system architecture, macOS support, and multi-nixpkgs functionality.

### System Outputs
* Enhanced `outputs/default.nix` to support macOS configurations (`darwinConfigurations`) alongside NixOS, added multi-nixpkgs support, and restructured system management for better modularity. [[1]](diffhunk://#diff-7df11e0171ef48e30e1215a7ec0a5bfca558bfeef8a73264b3a7570c68fd6023L3-R15) [[2]](diffhunk://#diff-7df11e0171ef48e30e1215a7ec0a5bfca558bfeef8a73264b3a7570c68fd6023R25-R124)

### Miscellaneous
* Updated versioning and metadata in various files (`libraries/default.nix`, `libraries/relative-to-root.nix`, `outputs/default.nix`) to reflect the latest changes. [[1]](diffhunk://#diff-a7dbfa28116b94508d2d89cbb323cc718903f601aa568a18f0160bbb26215154L6-R69) [[2]](diffhunk://#diff-026a17b58d4c8ac7ac9f3e532b875b18915247a19d2f5b5b0f4f0b049e84cd0fL7) [[3]](diffhunk://#diff-7df11e0171ef48e30e1215a7ec0a5bfca558bfeef8a73264b3a7570c68fd6023L3-R15)