### PR TITLE
feat(module): add darwin fonts module

### DIFF
--- a/modules/darwin/system/fonts/default.nix
+++ b/modules/darwin/system/fonts/default.nix
@@ -1,22 +1,45 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
-let
-  # Font package collections following Interface Segregation Principle
-  # Each collection has a single responsibility
+# System Fonts Module for Darwin (macOS)
+#
+# Version: 2.0.0
+# Last Updated: 2025-06-15
+#
+# This module provides a flexible and organized way to manage system fonts on Darwin systems.
+# It groups fonts into logical collections and provides configuration options for font smoothing
+# and default font settings.
+#
+# Example usage:
+# ```nix
+# system.fonts = {
+#   enable = true;
+#   default = "MonaspaceNe";
+#   collections = [ "system" "developer" ];
+#   smoothing = {
+#     enable = true;
+#     level = 1;  # Light smoothing
+#   };
+# };
+# ```
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  # Font package collections following Interface Segregation Principle.
+  # Each collection has a single responsibility.
   fontCollections = {
-    # System fonts - basic fonts that should be available on all systems
+    # System fonts - basic fonts that should be available on all systems.
     system = with pkgs; [
-      corefonts  # MS fonts
-      b612        # High legibility
+      corefonts # Microsoft core fonts
+      b612 # High legibility font
       source-sans
       inter
       lexend
-      monaspace   # Modern monospace font
+      monaspace # Modern monospace font
     ];
 
-    # UI/Icon fonts - for applications and UI elements
+    # UI/Icon fonts - for applications and UI elements.
     ui = with pkgs; [
       material-icons
       material-design-icons
@@ -24,122 +47,173 @@ let
       comic-neue
     ];
 
-    # Emoji fonts - for emoji support
+    # Emoji fonts - for emoji support.
     emoji = with pkgs; [
       noto-fonts-color-emoji
       noto-fonts-monochrome-emoji
     ];
 
-    # Developer fonts - monospace fonts for coding
+    # Developer fonts - monospace fonts for coding.
     developer = with pkgs; [
       nerd-fonts.fira-code
       nerd-fonts.hack
       nerd-fonts.sauce-code-pro
       nerd-fonts.symbols-only
-      cascadia-code  # Modern monospace font
+      cascadia-code # Modern monospace font
     ];
   };
-  
-  # Default font settings
+
+  # Default font name to use system-wide.
   defaultFont = "MonaspaceNe";
 
-  # Default font collections to enable
-  defaultEnabledCollections = [ "system" "ui" "emoji" "developer" ];
+  # Default font collections to enable.
+  defaultEnabledCollections = [
+    "system"
+    "ui"
+    "emoji"
+    "developer"
+  ];
 
-  # Darwin-specific font configuration
+  # Darwin-specific font configuration.
   cfg = config.system.fonts;
 
-  # Helper function to get enabled font packages
-  getEnabledFontPackages = collections: 
-    let
-      # Filter out non-existent collections
-      validCollections = filter (name: hasAttr name fontCollections) collections;
-    in
-      concatMap (name: getAttr name fontCollections) validCollections;
-
+  # Helper function to get enabled font packages.
+  #
+  # Type: listOf str -> listOf package
+  getEnabledFontPackages = collections: let
+    # Filter out non-existent collections.
+    validCollections = filter (name: hasAttr name fontCollections) collections;
+  in
+    concatMap (name: getAttr name fontCollections) validCollections;
 in {
   options.system = {
     fonts = {
       enable = mkEnableOption "system font configuration";
-      
-      # Default font name
+
       default = mkOption {
         type = types.str;
         default = defaultFont;
-        description = "Default system font name";
+        description = ''
+          The default system font to be used by applications.
+
+          Note: The specified font must be present in one of the enabled
+          collections or in extraPackages. The font name should exactly match
+          the system's font name (case-sensitive).
+
+          Common font names:
+          - MonaspaceNe (default)
+          - SF Pro
+          - Helvetica Neue
+          - Arial
+        '';
         example = "MonaspaceNe";
       };
 
-      # Font collections to enable (system, ui, emoji, developer)
       collections = mkOption {
-        type = with types; listOf str;
+        type = with types; listOf (enum (attrNames fontCollections));
         default = defaultEnabledCollections;
         description = ''
-          List of font collections to enable. Available collections:
+          List of font collections to enable. Collections group related fonts
+          for specific use cases, making it easy to manage font categories.
+
+          Available collections:
+
           - system: Basic system fonts
+            - corefonts (Arial, Times New Roman, etc.)
+            - Inter, Lexend (modern UI fonts)
+            - Monaspace (default monospace)
+
           - ui: UI and icon fonts
-          - emoji: Emoji fonts
+            - Material Icons
+            - Work Sans
+            - Comic Neue
+
+          - emoji: Emoji support
+            - Noto Color Emoji
+            - Noto Emoji (monochrome)
+
           - developer: Developer/monospace fonts
+            - Fira Code (with ligatures)
+            - Hack
+            - Sauce Code Pro
+            - Nerd Fonts symbols
+            - Cascadia Code
         '';
-        example = literalExpression ''[ "system" "developer" ]'';
+        example = literalExpression ''          [
+                    "system"    # Core system fonts
+                    "developer" # Developer fonts
+                  ]'';
       };
-      
-      # Allow users to specify additional font packages to install
+
       extraPackages = mkOption {
         type = with types; listOf package;
         default = [];
-        description = "Additional font packages to install";
-        example = literalExpression "[ pkgs.fira-code ]";
+        description = ''
+          Additional font packages to install beyond the defined collections.
+
+          Use this for:
+          - Custom fonts not in any collection
+          - Specific font variants
+          - Experimental or temporary font installations
+
+          Example:
+          ```nix
+          extraPackages = with pkgs; [
+            fira-code
+            jetbrains-mono
+          ];
+          ```
+        '';
+        example = literalExpression "[
+          pkgs.fira-code
+          pkgs.jetbrains-mono
+        ]";
       };
-      
-      # Font smoothing configuration (Darwin-specific)
+
       smoothing = {
-        enable = mkEnableOption "font smoothing" // {
-          default = true;
-        };
-        
-        # AppleFontSmoothing values:
-        # 0: No smoothing (crisp)
-        # 1: Light smoothing (default)
-        # 2: Medium smoothing
-        # 3: Strong smoothing
+        enable =
+          mkEnableOption "font smoothing"
+          // {
+            default = true;
+            description = "Enable macOS font smoothing (subpixel antialiasing)";
+          };
+
         level = mkOption {
           type = types.ints.between 0 3;
           default = 1;
           description = ''
-            Font smoothing level (0-3):
-            0 = No smoothing (crisp)
-            1 = Light smoothing (default)
-            2 = Medium smoothing
-            3 = Strong smoothing
+            Controls the level of font smoothing (subpixel antialiasing) on macOS.
+
+            Available levels:
+            - 0: No smoothing (crisp, may appear jagged on non-retina displays)
+            - 1: Light smoothing (default, good balance for most displays)
+            - 2: Medium smoothing (smoother, may appear slightly blurry)
+            - 3: Strong smoothing (maximum, may appear too soft)
+
+            Note: The effect is most noticeable on non-retina displays. On Retina
+            displays, the difference between levels is subtle.
           '';
+          example = 1;
         };
       };
     };
   };
-  
+
   config = mkIf cfg.enable (mkMerge [
     {
-      # Install the specified font packages
-      fonts.packages = 
-        # Get enabled font collections
-        (getEnabledFontPackages cfg.collections) 
-        # Add any extra packages
+      fonts.packages =
+        (getEnabledFontPackages cfg.collections)
         ++ cfg.extraPackages;
-      
-      # Enable icons in tooling
+
       environment.variables = {
         LOG_ICONS = "true";
-        # Set default font for applications that respect XDG spec
         XDG_DEFAULT_FONT = cfg.default;
       };
-      
-      # Set font smoothing defaults if enabled
+
       system.defaults.NSGlobalDomain = mkIf cfg.smoothing.enable {
         AppleFontSmoothing = cfg.smoothing.level;
       };
-      
-      # Require primaryUser to be set if using font smoothing
+
       assertions = optionals cfg.smoothing.enable [
         {
           assertion = config.system.primaryUser != null;

--- a/modules/darwin/system/fonts/default.nix
+++ b/modules/darwin/system/fonts/default.nix
@@ -1,0 +1,154 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  # Font package collections following Interface Segregation Principle
+  # Each collection has a single responsibility
+  fontCollections = {
+    # System fonts - basic fonts that should be available on all systems
+    system = with pkgs; [
+      corefonts  # MS fonts
+      b612        # High legibility
+      source-sans
+      inter
+      lexend
+      monaspace   # Modern monospace font
+    ];
+
+    # UI/Icon fonts - for applications and UI elements
+    ui = with pkgs; [
+      material-icons
+      material-design-icons
+      work-sans
+      comic-neue
+    ];
+
+    # Emoji fonts - for emoji support
+    emoji = with pkgs; [
+      noto-fonts-color-emoji
+      noto-fonts-monochrome-emoji
+    ];
+
+    # Developer fonts - monospace fonts for coding
+    developer = with pkgs; [
+      nerd-fonts.fira-code
+      nerd-fonts.hack
+      nerd-fonts.sauce-code-pro
+      nerd-fonts.symbols-only
+      cascadia-code  # Modern monospace font
+    ];
+  };
+  
+  # Default font settings
+  defaultFont = "MonaspaceNe";
+
+  # Default font collections to enable
+  defaultEnabledCollections = [ "system" "ui" "emoji" "developer" ];
+
+  # Darwin-specific font configuration
+  cfg = config.system.fonts;
+
+  # Helper function to get enabled font packages
+  getEnabledFontPackages = collections: 
+    let
+      # Filter out non-existent collections
+      validCollections = filter (name: hasAttr name fontCollections) collections;
+    in
+      concatMap (name: getAttr name fontCollections) validCollections;
+
+in {
+  options.system = {
+    fonts = {
+      enable = mkEnableOption "system font configuration";
+      
+      # Default font name
+      default = mkOption {
+        type = types.str;
+        default = defaultFont;
+        description = "Default system font name";
+        example = "MonaspaceNe";
+      };
+
+      # Font collections to enable (system, ui, emoji, developer)
+      collections = mkOption {
+        type = with types; listOf str;
+        default = defaultEnabledCollections;
+        description = ''
+          List of font collections to enable. Available collections:
+          - system: Basic system fonts
+          - ui: UI and icon fonts
+          - emoji: Emoji fonts
+          - developer: Developer/monospace fonts
+        '';
+        example = literalExpression ''[ "system" "developer" ]'';
+      };
+      
+      # Allow users to specify additional font packages to install
+      extraPackages = mkOption {
+        type = with types; listOf package;
+        default = [];
+        description = "Additional font packages to install";
+        example = literalExpression "[ pkgs.fira-code ]";
+      };
+      
+      # Font smoothing configuration (Darwin-specific)
+      smoothing = {
+        enable = mkEnableOption "font smoothing" // {
+          default = true;
+        };
+        
+        # AppleFontSmoothing values:
+        # 0: No smoothing (crisp)
+        # 1: Light smoothing (default)
+        # 2: Medium smoothing
+        # 3: Strong smoothing
+        level = mkOption {
+          type = types.ints.between 0 3;
+          default = 1;
+          description = ''
+            Font smoothing level (0-3):
+            0 = No smoothing (crisp)
+            1 = Light smoothing (default)
+            2 = Medium smoothing
+            3 = Strong smoothing
+          '';
+        };
+      };
+    };
+  };
+  
+  config = mkIf cfg.enable (mkMerge [
+    {
+      # Install the specified font packages
+      fonts.packages = 
+        # Get enabled font collections
+        (getEnabledFontPackages cfg.collections) 
+        # Add any extra packages
+        ++ cfg.extraPackages;
+      
+      # Enable icons in tooling
+      environment.variables = {
+        LOG_ICONS = "true";
+        # Set default font for applications that respect XDG spec
+        XDG_DEFAULT_FONT = cfg.default;
+      };
+      
+      # Set font smoothing defaults if enabled
+      system.defaults.NSGlobalDomain = mkIf cfg.smoothing.enable {
+        AppleFontSmoothing = cfg.smoothing.level;
+      };
+      
+      # Require primaryUser to be set if using font smoothing
+      assertions = optionals cfg.smoothing.enable [
+        {
+          assertion = config.system.primaryUser != null;
+          message = ''
+            The option `system.fonts.smoothing.enable` requires `system.primaryUser` to be set.
+            Please set `system.primaryUser` to the name of the primary user.
+          '';
+        }
+      ];
+    }
+  ]);
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin.nix
@@ -28,7 +28,7 @@
       # Convert relative paths to absolute paths using the project root
       (map libraries.relativeToRoot [
         # Common system modules
-
+        "modules/darwin/system/fonts/default.nix"
         # "modules/darwin/default.nix"
         # "modules/shared/default.nix"
 
@@ -40,11 +40,17 @@
       ])
       # Additional modules can be added here
       ++ [
-        # Inline module example
-        # {
-        #   system.stateVersion = 6;  # Should match the version of nix-darwin you're using
-        #   networking.hostName = name;
-        # }
+        # System configuration
+        {
+          system.stateVersion = 6; # Match your nix-darwin version
+          networking.hostName = name;
+
+          # Set the primary user for user-specific configurations
+          system.primaryUser = "aytordev";
+
+          # Configure system fonts
+          system.fonts.enable = true;
+        }
       ];
 
     # User-level modules (Home Manager configuration)
@@ -68,7 +74,6 @@
       # Add any additional arguments needed by modules
       hostName = name;
     };
-
 in {
   # The final darwin configuration for this host
   darwinConfigurations.${name} = libraries.macosSystem systemArgs;


### PR DESCRIPTION
This pull request introduces a new system fonts module for Darwin (macOS) and integrates it into the `aarch64-darwin` system configuration. The changes focus on modularizing font management, enabling flexible configurations, and ensuring compatibility with user-specific settings.

### New System Fonts Module for Darwin

* [`modules/darwin/system/fonts/default.nix`](diffhunk://#diff-9d0f1c867f8a4245aa6d8bff9be2f182bd321f24c498502327538760413e5ba6R1-R228): Added a comprehensive system fonts module that organizes fonts into logical collections (e.g., `system`, `ui`, `emoji`, `developer`) and provides configuration options for font smoothing and default font settings. Example usage and documentation are included.

### Integration into `aarch64-darwin` Configuration

* [`supported-systems/aarch64-darwin/src/wang-lin.nix`](diffhunk://#diff-7003305d197acd8b449396993aed90628200b903e6d849f66ddee0912ce7f605L31-R31): Integrated the new fonts module by adding its path to the list of system modules (`libraries.relativeToRoot`).
* [`supported-systems/aarch64-darwin/src/wang-lin.nix`](diffhunk://#diff-7003305d197acd8b449396993aed90628200b903e6d849f66ddee0912ce7f605L43-R53): Updated the system configuration to enable the fonts module and set `system.primaryUser` for user-specific configurations.