### PR TITLE
feat(modules): add homebrew module and documentation

### DIFF
--- a/modules/darwin/tools/README.md
+++ b/modules/darwin/tools/README.md
@@ -1,0 +1,73 @@
+# 🛠 Darwin Tools
+
+This directory contains modules for managing various tools on Darwin (macOS) systems.
+
+## 📋 Table of Contents
+
+- [Available Modules](#-available-modules)
+  - [Homebrew](#-homebrew)
+- [Adding New Tools](#-adding-new-tools)
+
+## 🧩 Available Modules
+
+### 🍺 Homebrew (`homebrew/`)
+
+Manages Homebrew package manager configuration.
+
+#### 📋 Prerequisites
+
+Before using this module, ensure Homebrew is installed:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Follow the post-installation instructions to add Homebrew to your PATH
+```
+
+#### 🚀 Usage
+
+Enable Homebrew in your host configuration:
+
+```nix
+{
+  tools.homebrew.enable = true;
+}
+```
+
+#### ✨ Features
+
+- Configures Homebrew environment variables
+- Manages Homebrew analytics settings
+- Controls auto-update behavior
+- Configures cleanup and upgrade policies
+
+#### ⚙️ Configuration
+
+All available options are documented in the module's inline documentation (`homebrew/default.nix`).
+
+## ➕ Adding New Tools
+
+1. **Create Module Directory**
+   ```bash
+   mkdir -p modules/darwin/tools/new-tool
+   ```
+
+2. **Implement Module**
+   - Create `default.nix` with your module implementation
+   - Follow Nix module conventions
+   - Include comprehensive documentation
+
+3. **Update Documentation**
+   - Add a section in this README
+   - Document prerequisites
+   - Include usage examples
+   - List configuration options
+
+4. **Test Thoroughly**
+   - Test on all supported systems
+   - Verify documentation accuracy
+   - Check for side effects
+
+## 🤝 Contributing
+
+See the main [CONTRIBUTING.md](../../../../CONTRIBUTING.md) for contribution guidelines.

--- a/modules/darwin/tools/homebrew/default.nix
+++ b/modules/darwin/tools/homebrew/default.nix
@@ -1,0 +1,95 @@
+# Homebrew Module
+#
+# This module provides configuration for the Homebrew package manager on Darwin systems.
+# It sets up Homebrew with recommended settings and environment variables.
+#
+# ## Features
+#
+# - Configures Homebrew with secure defaults
+# - Enables automatic updates and cleanup
+# - Sets recommended environment variables
+# - Supports Homebrew Bundle for declarative package management
+#
+# ## Options
+#
+# - `tools.homebrew.enable`: Enable Homebrew configuration (default: false)
+#
+# ## Example
+#
+# ```nix
+# # Enable Homebrew with default settings
+# tools.homebrew.enable = true;
+# ```
+# Version: 2.0.0
+# Last Updated: 2025-06-20
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib) mkEnableOption mkIf;
+
+  cfg = config.tools.homebrew;
+in {
+  options.tools.homebrew = {
+    enable = mkEnableOption "Homebrew package manager";
+    # Note: Additional options can be added here following the pattern:
+    # optionName = mkOption {
+    #   type = types.bool;
+    #   default = false;
+    #   description = "Description of the option";
+    # };
+  };
+
+  config = mkIf cfg.enable {
+    # Set Homebrew environment variables for better security and user experience
+    # See: https://docs.brew.sh/Manpage#environment
+    environment.variables = {
+      # Use bat for better paging of output
+      HOMEBREW_BAT = "1";
+      # Disable analytics for privacy
+      HOMEBREW_NO_ANALYTICS = "1";
+      # Prevent insecure redirects
+      HOMEBREW_NO_INSECURE_REDIRECT = "1";
+    };
+
+    # Main Homebrew configuration
+    homebrew = {
+      # Enable Homebrew integration
+      enable = true;
+
+      # Global Homebrew settings
+      # See: https://nix-community.github.io/home-manager/options.xhtml#opt-homebrew.global
+      global = {
+        # Enable Brewfile support for declarative package management
+        brewfile = true;
+        # Automatically update Homebrew before installing packages
+        autoUpdate = true;
+      };
+
+      # Configuration for Homebrew activation behavior
+      # See: https://nix-community.github.io/home-manager/options.xhtml#opt-homebrew.onActivation
+      onActivation = {
+        # Run `brew update` before installing packages
+        autoUpdate = true;
+        # Clean up old versions of installed formulae and casks
+        cleanup = "uninstall";
+        # Upgrade all installed packages
+        upgrade = true;
+      };
+
+      # Default Homebrew taps to include
+      # See: https://docs.brew.sh/Taps
+      taps = [
+        # Required for Brewfile support
+        # "homebrew/bundle" - This tap is now empty and all its contents were either deleted or migrated.
+        # Required for managing services
+        # "homebrew/services" - This tap is now empty and all its contents were either deleted or migrated.
+      ];
+
+      # Note: Add packages using:
+      # brews = [ "package1" "package2" ];
+      # casks = [ "app1" "app2" ];
+    };
+  };
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -27,12 +27,16 @@
     darwin-modules =
       # Convert relative paths to absolute paths using the project root
       (map libraries.relativeToRoot [
-        # Common system modules
+        # Common modules
+        ## System modules
         "modules/shared/nix/default.nix"
         "modules/darwin/system/fonts/default.nix"
         "modules/darwin/system/interface/default.nix"
         "modules/darwin/system/input/default.nix"
         "modules/darwin/system/networking/default.nix"
+
+        ## Tools
+        "modules/darwin/tools/homebrew/default.nix"
 
         # Host-specific system configuration
         # "hosts/darwin-${name}/system.nix"
@@ -52,6 +56,9 @@
 
           # Configure system fonts
           system.fonts.enable = true;
+
+          # Configure Homebrew
+          tools.homebrew.enable = true;
         }
       ];
 


### PR DESCRIPTION
This pull request introduces a new Homebrew module for Darwin systems, updates documentation, and integrates the module into the `aarch64-darwin` system configuration. The changes focus on enhancing macOS tool management and improving modularity.

### Homebrew Module Implementation:
* [`modules/darwin/tools/homebrew/default.nix`](diffhunk://#diff-321985b8ed4cde462ad078d203d60448c64659d0d0697c9997a6a1bd2d903b49R1-R95): Added a new Homebrew module with options for enabling Homebrew, configuring environment variables, and managing Homebrew settings such as auto-updates, cleanup, and package upgrades.

### Documentation Updates:
* [`modules/darwin/tools/README.md`](diffhunk://#diff-660e64e6fc80a1077b778e62cee566059fb26e49942a7c6b4794effcfd69cf51R1-R73): Created a comprehensive README for Darwin tools, including details about the new Homebrew module, its features, usage, configuration, and instructions for adding new tools.

### System Configuration Integration:
* `supported-systems/aarch64-darwin/src/wang-lin/default.nix`: 
  - Added the Homebrew module to the list of included modules for the `aarch64-darwin` system.
  - Enabled Homebrew configuration in the system settings.