### PR TITLE
docs(modules): add README files for darwin/system and shared modules

### DIFF
--- a/modules/darwin/system/README.md
+++ b/modules/darwin/system/README.md
@@ -1,0 +1,29 @@
+# Darwin System Configuration
+
+This directory contains system-level configurations for Darwin (macOS) systems. It includes modules for customizing various system aspects while maintaining consistency across different Darwin machines.
+
+## Structure
+
+- `fonts/`: System font configurations and custom font installations
+- `input/`: Input device configurations (keyboard, trackpad, etc.)
+- `interface/`: User interface customizations (dock, menu bar, etc.)
+- `networking/`: Network-related configurations and settings
+
+## Usage
+
+These modules are automatically included in the system configuration. To modify any system settings, edit the corresponding module in its respective subdirectory.
+
+## Adding New Configurations
+
+1. Create a new directory for your configuration if it doesn't fit existing categories
+2. Add a `default.nix` file that exports your configuration
+3. Update the parent module to import your new configuration
+
+## Quality Checks
+
+This module includes the following code quality tools:
+- `alejandra` for Nix formatting
+- `statix` for Nix linting
+- `deadnix` for dead code detection
+
+Run `nix flake check` to verify your changes pass all quality checks.

--- a/modules/shared/README.md
+++ b/modules/shared/README.md
@@ -1,0 +1,34 @@
+# Shared Modules
+
+This directory contains modules that are shared across different system types (Darwin, Linux, etc.). These modules provide common functionality and configurations that can be reused across different environments.
+
+## Structure
+
+- `nix/`: Nix-specific configurations and utilities that are not specific to any particular OS
+
+## Usage
+
+These modules are designed to be imported and used by other system configurations. They provide common functionality that can be leveraged across different environments.
+
+## Adding New Shared Modules
+
+1. Create a new directory for your shared functionality
+2. Add a `default.nix` file that exports your module
+3. Ensure your module is OS-agnostic or properly handles different operating systems
+4. Document any platform-specific considerations
+
+## Code Quality
+
+All shared modules should follow the project's code quality standards:
+- Use `alejandra` for consistent Nix formatting
+- Run `statix` to catch common Nix antipatterns
+- Use `deadnix` to find and remove unused code
+- Include appropriate type annotations where necessary
+
+## Best Practices
+
+- Keep shared modules focused on a single responsibility
+- Document any assumptions about the host system
+- Use conditional logic to handle platform differences when necessary
+- Include appropriate error messages for unsupported platforms
+- Keep dependencies minimal to maintain broad compatibility


### PR DESCRIPTION
This pull request adds comprehensive documentation for the `Darwin` system configuration and shared modules, improving clarity and usability for developers working with these configurations.

### Documentation for `Darwin` system configuration:

* Added a README (`modules/darwin/system/README.md`) detailing the structure, usage, and guidelines for modifying system-level configurations on Darwin systems. It includes sections on fonts, input devices, user interface customizations, and networking.
* Included instructions for adding new configurations and running quality checks using tools like `alejandra`, `statix`, and `deadnix`.

### Documentation for shared modules:

* Added a README (`modules/shared/README.md`) describing the purpose and structure of shared modules, which provide reusable functionality across different system types.
* Provided guidelines for adding new shared modules, including considerations for OS-agnostic design and platform-specific handling.
* Outlined best practices for shared modules, such as maintaining single responsibility, documenting assumptions, and minimizing dependencies for compatibility.