### PR TITLE
chore(home): update module versions and documentation

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -6,8 +6,8 @@
 # This configuration is specific to Darwin (macOS) systems and includes packages and settings
 # that should only apply to this user on this specific host.
 #
-# Maintainer: Aytor Vicente Martinez <me@aytor.dev>
-# Last Updated: 2025-06-23
+# Version: 2.0.1
+# Last Updated: 2025-06-23fa
 {
   config,
   lib,
@@ -21,11 +21,11 @@
   home.stateVersion = "25.11";
 
   # Enable and configure the user module
-  user = {
-    enable = true;
-    name = "aytordev";
-    home = "/Users/aytordev";
-  };
+  user.enable = true;
+  # The username for the account
+  user.name = "aytordev";
+  # The home directory for the account
+  user.home = "/Users/aytordev";
 
   # Example configurations (commented out for reference):
   # ====================================================

--- a/modules/home/user/default.nix
+++ b/modules/home/user/default.nix
@@ -4,7 +4,7 @@
 # across different platforms. It handles user-specific settings, home directory structure,
 # and ensures consistent user environment setup.
 #
-# Maintainer: Aytor Vicente Martinez <me@aytor.dev>
+# Version: 2.0.0
 # Last Updated: 2025-06-23
 {
   config,


### PR DESCRIPTION
This pull request includes updates to the `default.nix` configuration files for Darwin systems and user-specific modules. The changes primarily focus on improving metadata clarity and enhancing code readability.

### Metadata updates:

* [`homes/aarch64-darwin/aytordev@wang-lin/default.nix`](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bL9-R10): Replaced the `Maintainer` field with a `Version` field for better version tracking.
* [`modules/home/user/default.nix`](diffhunk://#diff-6f1455d26683a4b50a4c7faa149972652124276fb3165d4641ef82e95425aaf6L7-R7): Replaced the `Maintainer` field with a `Version` field and updated the version to `2.0.0`.

### Code readability improvements:

* [`homes/aarch64-darwin/aytordev@wang-lin/default.nix`](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bL24-R28): Enhanced readability by adding comments to the `user` module configuration fields (`enable`, `name`, and `home`).