### PR TITLE
feat(networking-module): update darwin networking

### DIFF
--- a/modules/darwin/system/fonts/default.nix
+++ b/modules/darwin/system/fonts/default.nix
@@ -25,9 +25,7 @@
   pkgs,
   libraries,
   ...
-}:
-
-let
+}: let
   inherit (lib) types mkIf mkOption;
 
   # Import shared fonts module
@@ -35,9 +33,8 @@ let
 
   # Darwin-specific font configuration
   cfg = config.system.fonts;
-
 in {
-  imports = [ sharedFonts ];
+  imports = [sharedFonts];
 
   options.system.fonts = {
     # Font smoothing configuration for macOS
@@ -72,30 +69,39 @@ in {
 
     # Configure font smoothing if enabled
     system.defaults.NSGlobalDomain = mkIf (cfg.smoothing != null) {
-      AppleFontSmoothing = if cfg.smoothing.enable then cfg.smoothing.level else 0;
+      AppleFontSmoothing =
+        if cfg.smoothing.enable
+        then cfg.smoothing.level
+        else 0;
     };
 
     # Install fonts through homebrew for better macOS integration
     # homebrew.casks = [ "font-hack-nerd-font" "font-fira-code" ];
 
     # Add assertions for font smoothing configuration
-    assertions = (
-      if cfg.smoothing != null then [
-        {
-          assertion = cfg.smoothing.level >= 0 && cfg.smoothing.level <= 3;
-          message = "Font smoothing level must be between 0 and 3";
-        }
-      ] else []
-    ) ++ (
-      if cfg.smoothing != null && cfg.smoothing.enable then [
-        {
-          assertion = config.system.primaryUser != null;
-          message = ''
-            The option `system.fonts.smoothing.enable` requires `system.primaryUser` to be set.
-            Please set `system.primaryUser` to the name of the primary user.
-          '';
-        }
-      ] else []
-    );
+    assertions =
+      (
+        if cfg.smoothing != null
+        then [
+          {
+            assertion = cfg.smoothing.level >= 0 && cfg.smoothing.level <= 3;
+            message = "Font smoothing level must be between 0 and 3";
+          }
+        ]
+        else []
+      )
+      ++ (
+        if cfg.smoothing != null && cfg.smoothing.enable
+        then [
+          {
+            assertion = config.system.primaryUser != null;
+            message = ''
+              The option `system.fonts.smoothing.enable` requires `system.primaryUser` to be set.
+              Please set `system.primaryUser` to the name of the primary user.
+            '';
+          }
+        ]
+        else []
+      );
   };
 }

--- a/modules/darwin/system/networking/default.nix
+++ b/modules/darwin/system/networking/default.nix
@@ -131,15 +131,15 @@ in {
     # Apply DNS configuration
     networking.dns = config.system.networking.dns.servers;
 
-      # Apply firewall configuration
-      networking.applicationFirewall = {
-        enable = config.system.networking.firewall.enable;
-        blockAllIncoming = config.system.networking.firewall.blockAllIncoming;
-        enableStealthMode = config.system.networking.firewall.enableStealthMode;
-        # Logging is controlled by the system log level
-      };
+    # Apply firewall configuration
+    networking.applicationFirewall = {
+      enable = config.system.networking.firewall.enable;
+      blockAllIncoming = config.system.networking.firewall.blockAllIncoming;
+      enableStealthMode = config.system.networking.firewall.enableStealthMode;
+      # Logging is controlled by the system log level
+    };
 
-      # Note: Port-based firewall rules are not supported on Darwin
-      # Use application-level firewall rules or pf for advanced filtering
+    # Note: Port-based firewall rules are not supported on Darwin
+    # Use application-level firewall rules or pf for advanced filtering
   };
 }

--- a/modules/darwin/system/networking/default.nix
+++ b/modules/darwin/system/networking/default.nix
@@ -1,16 +1,16 @@
 # System Networking Module for Darwin (macOS)
 #
-# Version: 2.2.0
-# Last Updated: 2025-06-15
+# Version: 3.0.0
+# Last Updated: 2025-06-27
 #
 # This module provides comprehensive networking configuration for Darwin systems,
 # including DNS settings, firewall configuration, and network service management.
 #
 # ## Features
 # - Configure system-wide DNS servers
-# - Manage firewall settings and rules
-# - Set up network services and interfaces
-# - Configure network time synchronization
+# - Modern application firewall configuration
+# - Network service management
+# - Network time synchronization
 #
 # ## Example Usage
 # ```nix
@@ -24,11 +24,11 @@
 #
 #     # Firewall configuration
 #     firewall = {
-#       globalState = 1;  # 1 = enabled
-#       enableLogging = false;
-#       stealthMode = false;
-#       allowedTCPPorts = [80 443];
-#       allowedUDPPorts = [53 123];
+#       enable = true;  # Enable the firewall
+#       blockAllIncoming = false;  # Block all incoming connections when true
+#       enableStealthMode = false;  # Enable stealth mode (no ICMP responses)
+#       allowedTCPPorts = [80 443];  # Allowed TCP ports
+#       allowedUDPPorts = [53 123];  # Allowed UDP ports
 #     };
 #
 #     # Network time synchronization
@@ -53,40 +53,38 @@ with lib; let
     "2606:4700:4700::1001" # Cloudflare Secondary (IPv6)
   ];
 
-  # Default firewall settings
-  #
-  # These settings provide a balanced approach between security and usability.
-  # The firewall is enabled by default but with logging disabled to reduce disk I/O.
-  defaultFirewallSettings = {
-    globalstate = 1; # 1 = enabled
-    loggingenabled = 0; # Disable logging by default
-    stealthenabled = 0; # Disable stealth mode by default
-  };
-
   # Type definitions for module options
   #
   # These types ensure type safety and provide documentation for the module's options.
   dnsServerType = types.listOf (types.strMatching "^[0-9a-fA-F:.]+$");
 
-  # Firewall state type:
-  # - 0: Disabled
-  # - 1: Enabled (default)
-  # - 2: Block all incoming connections
-  firewallStateType =
-    types.enum [0 1 2]
-    // {
-      description = "Firewall state (0=disabled, 1=enabled, 2=block all)";
-    };
+  # Hostname validation regex (RFC 1123)
+  hostnameType = types.strMatching "^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$";
 in {
   # Main module options
   #
   # These options are available under `system.networking` in the system configuration.
   options.system.networking = {
-    # Whether to enable the networking module
+    # Host Identification
     #
-    # Type: boolean
-    # Default: true
-    enable = mkEnableOption "system networking configuration";
+    # Configure system identification and naming.
+    hostName = mkOption {
+      type = types.nullOr hostnameType;
+      default = null;
+      description = "The hostname of the system (e.g., 'my-macbook')";
+    };
+
+    computerName = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "User-friendly computer name (e.g., 'My MacBook')";
+    };
+
+    localHostName = mkOption {
+      type = types.nullOr hostnameType;
+      default = null;
+      description = "Local (Bonjour) hostname (e.g., 'My-MacBook')";
+    };
 
     # DNS Configuration
     #
@@ -103,19 +101,19 @@ in {
     #
     # Controls the application firewall settings and rules.
     firewall = {
-      globalState = mkOption {
-        type = firewallStateType;
-        default = defaultFirewallSettings.globalstate;
-        description = "Firewall state (0=disabled, 1=enabled, 2=block all)";
-      };
-      enableLogging = mkOption {
+      enable = mkOption {
         type = types.bool;
-        default = defaultFirewallSettings.loggingenabled == 1;
-        description = "Whether to enable firewall logging";
+        default = true;
+        description = "Enable the application firewall";
+      };
+      blockAllIncoming = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Block all incoming connections";
       };
       enableStealthMode = mkOption {
         type = types.bool;
-        default = defaultFirewallSettings.stealthenabled == 1;
+        default = false;
         description = "Enable stealth mode (don't respond to ICMP pings)";
       };
     };
@@ -125,23 +123,23 @@ in {
     # Apply network services configuration
     networking.knownNetworkServices = ["Wi-Fi" "Ethernet"];
 
+    # Set host identification if specified
+    networking.computerName = mkIf (config.system.networking.computerName != null) config.system.networking.computerName;
+    networking.hostName = mkIf (config.system.networking.hostName != null) config.system.networking.hostName;
+    networking.localHostName = mkIf (config.system.networking.localHostName != null) config.system.networking.localHostName;
+
     # Apply DNS configuration
     networking.dns = config.system.networking.dns.servers;
 
-    # Apply firewall configuration
-    system.defaults.alf = {
-      globalstate =
-        if config.system.networking.firewall.globalState == 1
-        then 1
-        else 0;
-      loggingenabled =
-        if config.system.networking.firewall.enableLogging
-        then 1
-        else 0;
-      stealthenabled =
-        if config.system.networking.firewall.enableStealthMode
-        then 1
-        else 0;
-    };
+      # Apply firewall configuration
+      networking.applicationFirewall = {
+        enable = config.system.networking.firewall.enable;
+        blockAllIncoming = config.system.networking.firewall.blockAllIncoming;
+        enableStealthMode = config.system.networking.firewall.enableStealthMode;
+        # Logging is controlled by the system log level
+      };
+
+      # Note: Port-based firewall rules are not supported on Darwin
+      # Use application-level firewall rules or pf for advanced filtering
   };
 }

--- a/modules/shared/system/fonts/default.nix
+++ b/modules/shared/system/fonts/default.nix
@@ -3,16 +3,14 @@
   lib,
   pkgs,
   ...
-}:
-
-let
+}: let
   inherit (lib) types mkOption;
 
   # Common fonts that should be available on all systems
   commonFonts = with pkgs; [
     # Desktop Fonts
-    corefonts  # MS fonts
-    b612  # High legibility
+    corefonts # MS fonts
+    b612 # High legibility
     material-icons
     material-design-icons
     work-sans
@@ -30,7 +28,6 @@ let
     monaspace
     nerd-fonts.symbols-only
   ];
-
 in {
   options.system.fonts = with types; {
     fonts = mkOption {
@@ -38,13 +35,13 @@ in {
       default = commonFonts;
       description = "List of font packages to install system-wide";
     };
-      
+
     default = mkOption {
       type = str;
       default = "MonaspaceNeon";
       description = "Default system font name";
     };
-      
+
     size = mkOption {
       type = addCheck int (n: n > 0);
       default = 13;

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -49,7 +49,11 @@
         # System configuration
         {
           system.stateVersion = 6; # Match your nix-darwin version
-          networking.hostName = name;
+
+          # Set the hostname
+          system.networking.hostName = name;
+          system.networking.computerName = "Mac Studio M3 Ultra (2025)";
+          system.networking.localHostName = name;
 
           # Set the primary user for user-specific configurations
           system.primaryUser = variables.username;


### PR DESCRIPTION
This pull request introduces updates to the Darwin system configuration modules, focusing on improving font and networking configuration. Key changes include refactoring code for better readability, adding new options for host identification, and modernizing firewall configuration.

### Font Configuration Updates:
* Refactored `modules/darwin/system/fonts/default.nix` to simplify code structure by merging `let` and `in` blocks. [[1]](diffhunk://#diff-9d0f1c867f8a4245aa6d8bff9be2f182bd321f24c498502327538760413e5ba6L28-L38) [[2]](diffhunk://#diff-9d0f1c867f8a4245aa6d8bff9be2f182bd321f24c498502327538760413e5ba6L75-R104)
* Updated font smoothing configuration logic to improve readability and maintainability.

### Networking Configuration Enhancements:
* Modernized firewall options in `modules/darwin/system/networking/default.nix`, replacing outdated settings with clearer and more flexible options (`enable`, `blockAllIncoming`, `enableStealthMode`). [[1]](diffhunk://#diff-055fd5b1a9a89d8c83de201e284fe62c3d3530e5cee1d2981415f42c8dda34c7L27-R31) [[2]](diffhunk://#diff-055fd5b1a9a89d8c83de201e284fe62c3d3530e5cee1d2981415f42c8dda34c7L106-R116)
* Added new host identification options (`hostName`, `computerName`, `localHostName`) to allow more granular system naming configurations. [[1]](diffhunk://#diff-055fd5b1a9a89d8c83de201e284fe62c3d3530e5cee1d2981415f42c8dda34c7L56-R87) [[2]](diffhunk://#diff-055fd5b1a9a89d8c83de201e284fe62c3d3530e5cee1d2981415f42c8dda34c7R126-R143)

### Shared Fonts Module Adjustments:
* Refactored `modules/shared/system/fonts/default.nix` for consistency with the Darwin fonts module, merging `let` and `in` blocks. [[1]](diffhunk://#diff-8d294f27781ed739ff2c570deb709ab556f2de6cd245c256bcef7d3d3b6c8249L6-R6) [[2]](diffhunk://#diff-8d294f27781ed739ff2c570deb709ab556f2de6cd245c256bcef7d3d3b6c8249L33)

### System-Specific Configuration:
* Updated `supported-systems/aarch64-darwin/src/wang-lin/default.nix` to include host identification options (`hostName`, `computerName`, `localHostName`) for better system personalization.