### PR TITLE
feat(system): refactor supported-system structure

### DIFF
--- a/libraries/macos-system/default.nix
+++ b/libraries/macos-system/default.nix
@@ -387,17 +387,22 @@
       # Prepare special arguments, ensuring both libraries and variables are properly passed through
       specialArgs = let
         baseArgs = merged.specialArgs or {};
-        inputArgs = lib.optionalAttrs (inputs ? libraries) {
-          inherit (inputs) libraries;
-        } // lib.optionalAttrs (inputs ? variables) {
-          inherit (inputs) variables;
-        };
-        directArgs = lib.optionalAttrs (systemArgs ? libraries) {
-          inherit (systemArgs) libraries;
-        } // lib.optionalAttrs (systemArgs ? variables) {
-          inherit (systemArgs) variables;
-        };
-      in baseArgs // inputArgs // directArgs;
+        inputArgs =
+          lib.optionalAttrs (inputs ? libraries) {
+            inherit (inputs) libraries;
+          }
+          // lib.optionalAttrs (inputs ? variables) {
+            inherit (inputs) variables;
+          };
+        directArgs =
+          lib.optionalAttrs (systemArgs ? libraries) {
+            inherit (systemArgs) libraries;
+          }
+          // lib.optionalAttrs (systemArgs ? variables) {
+            inherit (systemArgs) variables;
+          };
+      in
+        baseArgs // inputArgs // directArgs;
     in {
       inherit lib nix-darwin home-manager nixpkgs;
       system = merged.system;

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -53,15 +53,13 @@
         # Common modules
         "modules/home/user/default.nix"
 
-
-
         # Desktop environment
         # "home/darwin/desktop.nix"
       ])
       ++ (map libraries.relativeToRoot [
         # Host-specific user configuration
-        "homes/aarch64-darwin/aytordev@wang-lin/default.nix"      
-        ]);
+        "homes/aarch64-darwin/aytordev@wang-lin/default.nix"
+      ]);
   };
 
   # Combine modules with all other arguments
@@ -69,9 +67,9 @@
     modules
     // args # This includes all the original arguments like variables, lib, etc.
     // {
-    # Add any additional arguments needed by modules
-    hostName = name;
-  };
+      # Add any additional arguments needed by modules
+      hostName = name;
+    };
 in {
   # The final darwin configuration for this host
   darwinConfigurations.${name} = libraries.macosSystem systemArgs;

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -3,8 +3,11 @@
 # This file defines host-specific module configurations for the wang-lin system.
 # It serves as a central place to manage and organize all module configurations
 # specific to this host.
-
-{lib, variables, ...}: {
+{
+  lib,
+  variables,
+  ...
+}: {
   # Add any host-specific module configurations here
   # This is a good place to set default values or overrides for modules
   # that are specific to this host.


### PR DESCRIPTION
This pull request refactors the Nix configuration for macOS systems, focusing on improving modularity and readability. The changes include restructuring how special arguments are prepared, centralizing host-specific configurations, and streamlining module definitions.

### Refactoring and modularization:

* **Enhanced special arguments handling**: Refactored the preparation of `specialArgs` in `libraries/macos-system/default.nix` to include both libraries and variables, ensuring better modularity and clarity.

* **Centralized host-specific system configuration**: Moved host-specific system settings for the `wang-lin` system into a dedicated file, `supported-systems/aarch64-darwin/src/wang-lin/system/default.nix`, to improve organization and maintainability.

### Streamlining module definitions:

* **Simplified module inclusion**: Updated `supported-systems/aarch64-darwin/src/wang-lin/default.nix` to use `libraries.relativeToRoot` for including host-specific system and user configurations, replacing inline definitions with references to external files for better modularity.