### PR TITLE
feat(modules): add darwin home module

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -27,6 +27,13 @@
   # The home directory for the account
   user.home = "/Users/aytordev";
 
+  # Enable and configure the home module
+  home.enable = true;
+  # The home files to manage
+  home.files = {};
+  # The XDG config files to manage
+  home.configs = {};
+
   # Example configurations (commented out for reference):
   # ====================================================
   #

--- a/modules/darwin/home/default.nix
+++ b/modules/darwin/home/default.nix
@@ -1,0 +1,105 @@
+# Home Manager Module for Darwin
+#
+# Manages user configuration files and XDG configs for Darwin systems.
+# Follows the same pattern as other modules in the codebase.
+#
+# Version: 1.0.0
+# Last Updated: 2025-06-27
+{
+  config,
+  lib,
+  ...
+}: {
+  options = {
+    home = {
+      enable = lib.mkEnableOption "home configuration" // {
+        description = ''
+          Whether to enable home configuration management.
+          When enabled, manages user configuration files and XDG configs.
+        '';
+      };
+
+      # User's home files
+      #
+      # Example:
+      # ```nix
+      # {
+      #   ".config/nvim/init.vim" = {
+      #     source = ./path/to/init.vim;
+      #   };
+      # }
+      #
+      files = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.submodule {
+          options = {
+            source = lib.mkOption {
+              type = lib.types.path;
+              description = "Source path for the file";
+              example = "./path/to/file";
+            };
+          };
+        });
+        default = {};
+        description = "Files to manage in the home directory";
+      };
+
+      # User's XDG config files
+      #
+      # Example:
+      # ```nix
+      # {
+      #   "git/config" = {
+      #     text = ''
+      #       [user]
+      #         name = "User Name"
+      #         email = "user@example.com"
+      #     '';
+      #   };
+      # }
+      #```
+      configs = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.submodule {
+          options = {
+            text = lib.mkOption {
+              type = lib.types.lines;
+              default = "";
+              description = "File content as text";
+              example = "key = value\n";
+            };
+            source = lib.mkOption {
+              type = lib.types.nullOr lib.types.path;
+              default = null;
+              description = "Source path for the file (alternative to text)";
+              example = "./path/to/config";
+            };
+          };
+        });
+        default = {};
+        description = "Files to manage in XDG config directory";
+      };
+    };
+  };
+
+  config = lib.mkIf config.home.enable (lib.mkMerge [
+    # Enable XDG by default for better organization
+    { xdg.enable = true; }
+
+    # Handle home files
+    (lib.mkIf (config.home.files != {}) {
+      home.file = lib.mapAttrs' (name: value: 
+        lib.nameValuePair name { inherit (value) source; }
+      ) config.home.files;
+    })
+
+    # Handle XDG config files with either source or text content
+    (lib.mkIf (config.home.configs != {}) {
+      xdg.configFile = lib.mapAttrs' (name: value: 
+        lib.nameValuePair name (
+          if value.source != null
+          then { source = value.source; }
+          else { text = value.text; }
+        )
+      ) config.home.configs;
+    })
+  ]);
+}

--- a/modules/darwin/home/default.nix
+++ b/modules/darwin/home/default.nix
@@ -12,12 +12,14 @@
 }: {
   options = {
     home = {
-      enable = lib.mkEnableOption "home configuration" // {
-        description = ''
-          Whether to enable home configuration management.
-          When enabled, manages user configuration files and XDG configs.
-        '';
-      };
+      enable =
+        lib.mkEnableOption "home configuration"
+        // {
+          description = ''
+            Whether to enable home configuration management.
+            When enabled, manages user configuration files and XDG configs.
+          '';
+        };
 
       # User's home files
       #
@@ -82,24 +84,30 @@
 
   config = lib.mkIf config.home.enable (lib.mkMerge [
     # Enable XDG by default for better organization
-    { xdg.enable = true; }
+    {xdg.enable = true;}
 
     # Handle home files
     (lib.mkIf (config.home.files != {}) {
-      home.file = lib.mapAttrs' (name: value: 
-        lib.nameValuePair name { inherit (value) source; }
-      ) config.home.files;
+      home.file =
+        lib.mapAttrs' (
+          name: value:
+            lib.nameValuePair name {inherit (value) source;}
+        )
+        config.home.files;
     })
 
     # Handle XDG config files with either source or text content
     (lib.mkIf (config.home.configs != {}) {
-      xdg.configFile = lib.mapAttrs' (name: value: 
-        lib.nameValuePair name (
-          if value.source != null
-          then { source = value.source; }
-          else { text = value.text; }
+      xdg.configFile =
+        lib.mapAttrs' (
+          name: value:
+            lib.nameValuePair name (
+              if value.source != null
+              then {source = value.source;}
+              else {text = value.text;}
+            )
         )
-      ) config.home.configs;
+        config.home.configs;
     })
   ]);
 }

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -52,6 +52,7 @@
       (map libraries.relativeToRoot [
         # Common modules
         "modules/home/user/default.nix"
+        "modules/darwin/home/default.nix"
 
         # Desktop environment
         # "home/darwin/desktop.nix"


### PR DESCRIPTION
This pull request introduces a new Home Manager module for Darwin systems, enabling configuration management for user home files and XDG config files. The changes include defining the module, adding configuration options, and integrating it into the supported systems.

### Addition of Home Manager Module for Darwin Systems

* [`modules/darwin/home/default.nix`](diffhunk://#diff-18ff18106c20639b7e9ad05085298bd4a776c99d040b9f1926e5709e9bc7b798R1-R113): Added a new Home Manager module for Darwin systems, which provides options for managing user home files (`home.files`) and XDG config files (`home.configs`). The module includes detailed descriptions and examples for each option.

### Integration and Usage

* [`homes/aarch64-darwin/aytordev@wang-lin/default.nix`](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bR30-R36): Enabled the home module and added configuration placeholders for managing home files and XDG configs.
* [`supported-systems/aarch64-darwin/src/wang-lin/default.nix`](diffhunk://#diff-80fa091607f0022f5215bf9e69c8ac7093fd2b605ccd9364cff9be483b24a3a5R55): Integrated the new Home Manager module into the list of supported modules for the system.