### PR TITLE
feat(security): add darwin sops secrets

### DIFF
--- a/modules/darwin/security/sops/default.nix
+++ b/modules/darwin/security/sops/default.nix
@@ -1,6 +1,10 @@
-{ config, lib, pkgs, inputs, ... }:
-
-let
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}: let
   cfg = config.darwin.security.sops;
   inherit (lib) mkEnableOption mkOption types mkIf mkMerge;
   inherit (builtins) isString;
@@ -38,9 +42,7 @@ let
       };
     };
   };
-
-in
-{
+in {
   options.darwin.security.sops = {
     enable = mkEnableOption "SOPS secrets management";
 
@@ -78,7 +80,7 @@ in
       sops = {
         defaultSopsFile = cfg.defaultSopsFile;
         age.keyFile = cfg.age.keyFile;
-        
+
         # Disable SSH key checking
         gnupg.sshKeyPaths = [];
       };
@@ -86,17 +88,25 @@ in
 
     # Generate secrets configuration
     {
-      sops.secrets = lib.mapAttrs (name: secret:
-        if builtins.isString secret then {
-          sopsFile = cfg.defaultSopsFile;
-          key = name;
-          path = secret;
-        } else {
-          inherit (secret) path;
-          sopsFile = if secret.sopsFile != null then secret.sopsFile else cfg.defaultSopsFile;
-          inherit (secret) key mode owner group;
-        }
-      ) cfg.secrets;
+      sops.secrets =
+        lib.mapAttrs (
+          name: secret:
+            if builtins.isString secret
+            then {
+              sopsFile = cfg.defaultSopsFile;
+              key = name;
+              path = secret;
+            }
+            else {
+              inherit (secret) path;
+              sopsFile =
+                if secret.sopsFile != null
+                then secret.sopsFile
+                else cfg.defaultSopsFile;
+              inherit (secret) key mode owner group;
+            }
+        )
+        cfg.secrets;
     }
   ]);
 }

--- a/modules/darwin/security/sops/default.nix
+++ b/modules/darwin/security/sops/default.nix
@@ -1,0 +1,120 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkEnableOption mkOption types;
+  inherit (lib.attrsets) mapAttrs optionalAttrs nameValuePair filterAttrs;
+  inherit (lib.lists) any optional;
+  inherit (lib.modules) mkIf mkMerge mkDefault;
+  inherit (lib.strings) hasInfix;
+
+  cfg = config.darwin.security.sops;
+  user = config.users.users.${config.user.name} or { home = ""; };
+  
+  # Helper function to create activation script for secrets
+  mkSecretScript = name: { path, mode, sopsFile, ... }@secret: let
+    secretName = builtins.baseNameOf path;
+    secretDir = builtins.dirOf path;
+  in ''
+    echo "Decrypting ${name} to ${path}..."
+    mkdir -p ${lib.escapeShellArg secretDir}
+    ${pkgs.sops}/bin/sops -d ${lib.escapeShellArg sopsFile} > ${lib.escapeShellArg path}
+    chmod ${mode} ${lib.escapeShellArg path}
+  '';
+
+  # Filter out secrets that have all required attributes
+  validSecrets = filterAttrs (n: v: v.path != null && v.sopsFile != null) cfg.secrets;
+  
+  # Generate activation scripts for all valid secrets
+  secretScripts = mapAttrs mkSecretScript validSecrets;
+  
+  # Create a script to decrypt all secrets
+  decryptScript = pkgs.writeShellScriptBin "decrypt-secrets" ''
+    set -e
+    ${lib.concatStringsSep "\n" (lib.attrValues secretScripts)}
+  '';
+  
+in
+{
+  options.darwin.security.sops = {
+    enable = mkEnableOption "SOPS secrets management";
+
+    defaultSopsFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Default SOPS file to use for secrets";
+    };
+
+    age = {
+      keyFile = mkOption {
+        type = types.nullOr types.path;
+        default = if user.home != "" then "${user.home}/.config/sops/age/keys.txt" else null;
+        defaultText = "$HOME/.config/sops/age/keys.txt";
+        description = "Path to the AGE key file";
+      };
+
+      sshKeyPaths = mkOption {
+        type = types.listOf types.path;
+        default = [ "${user.home}/.ssh/id_ed25519" "${user.home}/.ssh/id_rsa" ];
+        description = "List of SSH key paths for AGE decryption";
+      };
+    };
+
+    secrets = mkOption {
+      type = types.attrsOf (types.submodule ({ name, ... }: {
+        options = {
+          path = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            description = "Target path for the decrypted secret";
+          };
+
+          mode = mkOption {
+            type = types.str;
+            default = "0400";
+            description = "File permissions for the decrypted secret";
+          };
+
+          sopsFile = mkOption {
+            type = types.nullOr types.path;
+            default = cfg.defaultSopsFile;
+            description = "SOPS file containing the secret";
+          };
+        };
+      }));
+      default = { };
+      description = "Secrets configuration";
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      assertions = [
+        {
+          assertion = cfg.defaultSopsFile != null || !(any (s: s.sopsFile == null) (lib.attrValues cfg.secrets));
+          message = "Either defaultSopsFile must be set or each secret must specify sopsFile";
+        }
+        {
+          assertion = cfg.age.keyFile != null || cfg.age.sshKeyPaths != [];
+          message = "Either age.keyFile or age.sshKeyPaths must be set";
+        }
+      ];
+
+      # Add sops to system packages
+      environment.systemPackages = [ pkgs.sops ];
+      
+      # Create activation script for secrets
+      system.activationScripts.setupSecrets = {
+        text = ''
+          # Set up SOPS
+          export SOPS_AGE_KEY_FILE="${cfg.age.keyFile}"
+          ${lib.optionalString (cfg.age.sshKeyPaths != []) 
+            "export SOPS_AGE_KEY_FILE=\"${toString cfg.age.sshKeyPaths}\""}
+          
+          # Decrypt all secrets
+          ${decryptScript}/bin/decrypt-secrets
+        '';
+        deps = [ "users" ];
+      };
+    }
+  ]);
+}

--- a/modules/darwin/security/sops/default.nix
+++ b/modules/darwin/security/sops/default.nix
@@ -1,120 +1,102 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, inputs, ... }:
 
 let
-  inherit (lib) mkEnableOption mkOption types;
-  inherit (lib.attrsets) mapAttrs optionalAttrs nameValuePair filterAttrs;
-  inherit (lib.lists) any optional;
-  inherit (lib.modules) mkIf mkMerge mkDefault;
-  inherit (lib.strings) hasInfix;
-
   cfg = config.darwin.security.sops;
-  user = config.users.users.${config.user.name} or { home = ""; };
-  
-  # Helper function to create activation script for secrets
-  mkSecretScript = name: { path, mode, sopsFile, ... }@secret: let
-    secretName = builtins.baseNameOf path;
-    secretDir = builtins.dirOf path;
-  in ''
-    echo "Decrypting ${name} to ${path}..."
-    mkdir -p ${lib.escapeShellArg secretDir}
-    ${pkgs.sops}/bin/sops -d ${lib.escapeShellArg sopsFile} > ${lib.escapeShellArg path}
-    chmod ${mode} ${lib.escapeShellArg path}
-  '';
+  inherit (lib) mkEnableOption mkOption types mkIf mkMerge;
+  inherit (builtins) isString;
 
-  # Filter out secrets that have all required attributes
-  validSecrets = filterAttrs (n: v: v.path != null && v.sopsFile != null) cfg.secrets;
-  
-  # Generate activation scripts for all valid secrets
-  secretScripts = mapAttrs mkSecretScript validSecrets;
-  
-  # Create a script to decrypt all secrets
-  decryptScript = pkgs.writeShellScriptBin "decrypt-secrets" ''
-    set -e
-    ${lib.concatStringsSep "\n" (lib.attrValues secretScripts)}
-  '';
-  
+  # Type for secret options
+  secretType = types.submodule {
+    options = {
+      sopsFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "Path to the sops file containing this secret";
+      };
+      key = mkOption {
+        type = types.str;
+        description = "Key of the secret in the sops file";
+      };
+      path = mkOption {
+        type = types.str;
+        description = "Path where the decrypted secret should be stored";
+      };
+      mode = mkOption {
+        type = types.str;
+        default = "0400";
+        description = "Permissions mode for the decrypted file";
+      };
+      owner = mkOption {
+        type = types.str;
+        default = "root";
+        description = "Owner of the decrypted file";
+      };
+      group = mkOption {
+        type = types.str;
+        default = "wheel";
+        description = "Group of the decrypted file";
+      };
+    };
+  };
+
 in
 {
   options.darwin.security.sops = {
     enable = mkEnableOption "SOPS secrets management";
 
     defaultSopsFile = mkOption {
-      type = types.nullOr types.path;
-      default = null;
-      description = "Default SOPS file to use for secrets";
+      type = types.path;
+      description = "Default sops file to use for secrets";
+      example = "/path/to/secrets.yaml";
     };
 
     age = {
       keyFile = mkOption {
-        type = types.nullOr types.path;
-        default = if user.home != "" then "${user.home}/.config/sops/age/keys.txt" else null;
-        defaultText = "$HOME/.config/sops/age/keys.txt";
-        description = "Path to the AGE key file";
-      };
-
-      sshKeyPaths = mkOption {
-        type = types.listOf types.path;
-        default = [ "${user.home}/.ssh/id_ed25519" "${user.home}/.ssh/id_rsa" ];
-        description = "List of SSH key paths for AGE decryption";
+        type = types.path;
+        description = "Path to the age key file for decryption";
+        example = "/Users/username/.config/sops/age/keys.txt";
       };
     };
 
     secrets = mkOption {
-      type = types.attrsOf (types.submodule ({ name, ... }: {
-        options = {
-          path = mkOption {
-            type = types.nullOr types.path;
-            default = null;
-            description = "Target path for the decrypted secret";
-          };
-
-          mode = mkOption {
-            type = types.str;
-            default = "0400";
-            description = "File permissions for the decrypted secret";
-          };
-
-          sopsFile = mkOption {
-            type = types.nullOr types.path;
-            default = cfg.defaultSopsFile;
-            description = "SOPS file containing the secret";
-          };
+      type = types.attrsOf (types.either types.str secretType);
+      default = {};
+      description = "Attribute set of secrets to manage";
+      example = {
+        "github_ssh_private_key" = {
+          path = "/Users/username/.ssh/github_ed25519";
+          mode = "0600";
+          owner = "username";
         };
-      }));
-      default = { };
-      description = "Secrets configuration";
+      };
     };
   };
 
   config = mkIf cfg.enable (mkMerge [
+    # Base sops configuration
     {
-      assertions = [
-        {
-          assertion = cfg.defaultSopsFile != null || !(any (s: s.sopsFile == null) (lib.attrValues cfg.secrets));
-          message = "Either defaultSopsFile must be set or each secret must specify sopsFile";
-        }
-        {
-          assertion = cfg.age.keyFile != null || cfg.age.sshKeyPaths != [];
-          message = "Either age.keyFile or age.sshKeyPaths must be set";
-        }
-      ];
-
-      # Add sops to system packages
-      environment.systemPackages = [ pkgs.sops ];
-      
-      # Create activation script for secrets
-      system.activationScripts.setupSecrets = {
-        text = ''
-          # Set up SOPS
-          export SOPS_AGE_KEY_FILE="${cfg.age.keyFile}"
-          ${lib.optionalString (cfg.age.sshKeyPaths != []) 
-            "export SOPS_AGE_KEY_FILE=\"${toString cfg.age.sshKeyPaths}\""}
-          
-          # Decrypt all secrets
-          ${decryptScript}/bin/decrypt-secrets
-        '';
-        deps = [ "users" ];
+      sops = {
+        defaultSopsFile = cfg.defaultSopsFile;
+        age.keyFile = cfg.age.keyFile;
+        
+        # Disable SSH key checking
+        gnupg.sshKeyPaths = [];
       };
+    }
+
+    # Generate secrets configuration
+    {
+      sops.secrets = lib.mapAttrs (name: secret:
+        if builtins.isString secret then {
+          sopsFile = cfg.defaultSopsFile;
+          key = name;
+          path = secret;
+        } else {
+          inherit (secret) path;
+          sopsFile = if secret.sopsFile != null then secret.sopsFile else cfg.defaultSopsFile;
+          inherit (secret) key mode owner group;
+        }
+      ) cfg.secrets;
     }
   ]);
 }

--- a/modules/darwin/security/sops/default.nix
+++ b/modules/darwin/security/sops/default.nix
@@ -74,7 +74,8 @@
   # Create a secret configuration from an attribute set (advanced case)
   mkAttrsSecret = name: secret: {
     inherit (secret) path key mode owner group;
-    sopsFile = if secret ? sopsFile && secret.sopsFile != null
+    sopsFile =
+      if secret ? sopsFile && secret.sopsFile != null
       then secret.sopsFile
       else cfg.defaultSopsFile;
   };

--- a/modules/darwin/tools/homebrew/default.nix
+++ b/modules/darwin/tools/homebrew/default.nix
@@ -29,9 +29,9 @@
 }: let
   inherit (lib) mkEnableOption mkIf;
 
-  cfg = config.tools.homebrew;
+  cfg = config.darwin.tools.homebrew;
 in {
-  options.tools.homebrew = {
+  options.darwin.tools.homebrew = {
     enable = mkEnableOption "Homebrew package manager";
     # Note: Additional options can be added here following the pattern:
     # optionName = mkOption {

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -26,22 +26,23 @@
     darwin-modules =
       # Convert relative paths to absolute paths using the project root
       (map libraries.relativeToRoot [
-        # Common modules
-        ## System modules
-        "modules/darwin/nix/default.nix"
-        "modules/darwin/system/fonts/default.nix"
-        "modules/darwin/system/interface/default.nix"
-        "modules/darwin/system/input/default.nix"
-        "modules/darwin/system/networking/default.nix"
+          # Common modules
+          ## System modules
+          "modules/darwin/nix/default.nix"
+          "modules/darwin/system/fonts/default.nix"
+          "modules/darwin/system/interface/default.nix"
+          "modules/darwin/system/input/default.nix"
+          "modules/darwin/system/networking/default.nix"
 
-        ## Tools
-        "modules/darwin/tools/homebrew/default.nix"
+          ## Tools
+          "modules/darwin/tools/homebrew/default.nix"
 
-        ## Security
-        "modules/darwin/security/sops/default.nix"
-      ] ++ [
-        inputs.sops-nix.darwinModules.sops
-      ])
+          ## Security
+          "modules/darwin/security/sops/default.nix"
+        ]
+        ++ [
+          inputs.sops-nix.darwinModules.sops
+        ])
       # Additional modules can be added here
       ++ (map libraries.relativeToRoot [
         # Host-specific system configuration

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -36,6 +36,9 @@
 
         ## Tools
         "modules/darwin/tools/homebrew/default.nix"
+
+        ## Security
+        "modules/darwin/security/sops/default.nix"
       ])
       # Additional modules can be added here
       ++ (map libraries.relativeToRoot [

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -39,6 +39,8 @@
 
         ## Security
         "modules/darwin/security/sops/default.nix"
+      ] ++ [
+        inputs.sops-nix.darwinModules.sops
       ])
       # Additional modules can be added here
       ++ (map libraries.relativeToRoot [

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -9,8 +9,7 @@
   ...
 }: let
   sopsFolder = builtins.toString inputs.secrets + "/hard-secrets";
-in
-{
+in {
   # Add any host-specific module configurations here
   # This is a good place to set default values or overrides for modules
   # that are specific to this host.

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -7,7 +7,10 @@
   lib,
   inputs,
   ...
-}: {
+}: let
+  sopsFolder = builtins.toString inputs.secrets + "/sops";
+in
+{
   # Add any host-specific module configurations here
   # This is a good place to set default values or overrides for modules
   # that are specific to this host.
@@ -23,5 +26,10 @@
   system.primaryUser = inputs.secrets.username;
 
   # Configure Homebrew
-  tools.homebrew.enable = true;
+  darwin.tools.homebrew.enable = true;
+
+  # Configure SOPS
+  darwin.security.sops.enable = true;
+  darwin.security.sops.defaultSopsFile = "${sopsFolder}/${inputs.secrets.username}.yaml";
+  darwin.security.sops.age.keyFile = "/Users/${inputs.secrets.username}/.config/sops/age/keys.txt";
 }

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -8,7 +8,7 @@
   inputs,
   ...
 }: let
-  sopsFolder = builtins.toString inputs.secrets + "/sops";
+  sopsFolder = builtins.toString inputs.secrets + "/hard-secrets";
 in
 {
   # Add any host-specific module configurations here
@@ -32,4 +32,11 @@ in
   darwin.security.sops.enable = true;
   darwin.security.sops.defaultSopsFile = "${sopsFolder}/${inputs.secrets.username}.yaml";
   darwin.security.sops.age.keyFile = "/Users/${inputs.secrets.username}/.config/sops/age/keys.txt";
+
+  darwin.security.sops.secrets.github_ssh_private_key = {
+    key = "github_ssh_private_key";
+    path = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
+    mode = "0600";
+    owner = "${inputs.secrets.username}";
+  };
 }


### PR DESCRIPTION
This pull request introduces a new SOPS module for managing secrets in `darwin` configurations, updates the Homebrew module path, and integrates these changes into the `aarch64-darwin` system configuration. The most important changes include defining the SOPS module, updating the Homebrew module path, and configuring secrets management for the `aarch64-darwin` system.

### SOPS Module Definition:
* [`modules/darwin/security/sops/default.nix`](diffhunk://#diff-ce080f8693ff3b2a6e5f16480201b105308419cdaacaa222bc3528cba90cf494R1-R151): Added a new SOPS module with options for secrets management, including configurations for secret files, keys, destination paths, file permissions, owners, and groups. Helper functions (`mkStringSecret`, `mkAttrsSecret`, `mapSecret`) were added for creating secret configurations.

### Homebrew Module Path Update:
* [`modules/darwin/tools/homebrew/default.nix`](diffhunk://#diff-321985b8ed4cde462ad078d203d60448c64659d0d0697c9997a6a1bd2d903b49L32-R34): Updated the module path from `tools.homebrew` to `darwin.tools.homebrew` for consistency with the `darwin` namespace.

### Integration into `aarch64-darwin` System:
* [`supported-systems/aarch64-darwin/src/wang-lin/default.nix`](diffhunk://#diff-80fa091607f0022f5215bf9e69c8ac7093fd2b605ccd9364cff9be483b24a3a5R39-R44): Included the new SOPS module and its dependencies in the system's module list.
* [`supported-systems/aarch64-darwin/src/wang-lin/system/default.nix`](diffhunk://#diff-bc9905c66fbe88c05959b428d2a4283b89713269e648171a33c796685d07dd58L10-R12): Configured the SOPS module, enabling it and specifying the default SOPS file, age key file, and secrets (e.g., `github_ssh_private_key`). Updated the Homebrew configuration to use the new `darwin.tools.homebrew` path. [[1]](diffhunk://#diff-bc9905c66fbe88c05959b428d2a4283b89713269e648171a33c796685d07dd58L10-R12) [[2]](diffhunk://#diff-bc9905c66fbe88c05959b428d2a4283b89713269e648171a33c796685d07dd58L26-R40)