### PR TITLE
refactor(git): refactor git config module

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -37,6 +37,8 @@
 
   # Enable my git configuration
   applications.terminal.tools.git.enable = true;
+  applications.terminal.tools.git.signingKey = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
+  
 
   # Example configurations (commented out for reference):
   # ====================================================

--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -38,7 +38,6 @@
   # Enable my git configuration
   applications.terminal.tools.git.enable = true;
   applications.terminal.tools.git.signingKey = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
-  
 
   # Example configurations (commented out for reference):
   # ====================================================

--- a/modules/home/applications/terminal/tools/git/default.nix
+++ b/modules/home/applications/terminal/tools/git/default.nix
@@ -6,7 +6,7 @@
   inputs,
   ...
 }: let
-  inherit (lib) mkEnableOption mkIf;
+  inherit (lib) mkEnableOption mkIf mkForce mkOption;
 
   cfg = config.applications.terminal.tools.git;
 
@@ -45,15 +45,67 @@
     # User configuration
     userName = inputs.secrets.username;
     userEmail = inputs.secrets.useremail;
+
+    maintenance.enable = true;
+
+    delta.enable = true;
+    delta.options.dark = true;
+    # FIXME: module should accept a mergable list be composable
+    delta.options.features = mkForce "decorations side-by-side navigate catppuccin-macchiato";
+    delta.options.line-numbers = true;
+    delta.options.navigate = true;
+    delta.options.side-by-side = true;
+
+    difftastic.enableAsDifftool = true;
+    difftastic.background = "dark";
+    difftastic.display = "inline";
+
+    extraConfig.branch.sort = "-committerdate";
+    extraConfig.useHttpPath.enable = true;
+    extraConfig.fetch.prune = true;
+    extraConfig.init.defaultBranch = "main";
+    extraConfig.lfs.enable = true;
+    extraConfig.pull.rebase = true;
+    extraConfig.push.autoSetupRemote = true;
+    extraConfig.push.default = "current";
+    extraConfig.rerere.enabled = true;
+    extraConfig.rebase.autostash = true;
+    extraConfig.safe.directory = [
+              "~/${inputs.secrets.username}/"
+              "/etc/nixos"
+              "/etc/nix-darwin"
+            ];
+    
+    signing.key = cfg.signingKey;
+    signing.format = "ssh";
+    signing.signByDefault = cfg.signByDefault;
   };
 in {
   options.applications.terminal.tools.git = {
     enable = mkEnableOption "Git configuration";
+    
+    # Configurable signing key
+    signingKey = mkOption {
+      type = with lib.types; nullOr str;
+      default = null;
+      description = "Path to the SSH private key for commit signing";
+      example = "~/.ssh/id_ed25519";
+    };
+
+    # Whether to sign commits by default
+    signByDefault = mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to sign commits by default";
+    };
   };
 
-  config = mkIf cfg.enable {
+  config = let
+    cfg = config.applications.terminal.tools.git;
+  in mkIf cfg.enable {
     home.packages = gitPackages;
     programs.git = gitConfig;
+    programs.mergiraf.enable = true;
     home.shellAliases = shell-aliases;
   };
 }

--- a/modules/home/applications/terminal/tools/git/default.nix
+++ b/modules/home/applications/terminal/tools/git/default.nix
@@ -177,11 +177,9 @@ in {
 
         # Shell aliases for Git
         home.shellAliases = shell-aliases;
-      }
 
-      # Mergiraf configuration (Git merge conflict resolution tool)
-      (lib.mkIf (lib.hasAttr "mergiraf" config.programs) {
+        # Mergiraf configuration (Git merge conflict resolution tool)
         programs.mergiraf.enable = true;
-      })
+      }
     ]);
 }

--- a/modules/home/applications/terminal/tools/git/default.nix
+++ b/modules/home/applications/terminal/tools/git/default.nix
@@ -120,12 +120,14 @@
   };
 in {
   options.applications.terminal.tools.git = {
-    enable = mkEnableOption "Git configuration" // {
-      description = ''
-        Whether to enable the Git configuration module.
-        This includes Git itself, common tools, and configuration.
-      '';
-    };
+    enable =
+      mkEnableOption "Git configuration"
+      // {
+        description = ''
+          Whether to enable the Git configuration module.
+          This includes Git itself, common tools, and configuration.
+        '';
+      };
 
     # SSH key used for commit/tag signing
     #
@@ -163,22 +165,23 @@ in {
   # Module implementation
   config = let
     cfg = config.applications.terminal.tools.git;
-  in lib.mkIf cfg.enable (lib.mkMerge [
-    # Base configuration
-    {
-      # Install Git packages
-      home.packages = gitPackages;
+  in
+    lib.mkIf cfg.enable (lib.mkMerge [
+      # Base configuration
+      {
+        # Install Git packages
+        home.packages = gitPackages;
 
-      # Main Git configuration
-      programs.git = gitConfig;
+        # Main Git configuration
+        programs.git = gitConfig;
 
-      # Shell aliases for Git
-      home.shellAliases = shell-aliases;
-    }
+        # Shell aliases for Git
+        home.shellAliases = shell-aliases;
+      }
 
-    # Mergiraf configuration (Git merge conflict resolution tool)
-    (lib.mkIf (lib.hasAttr "mergiraf" config.programs) {
-      programs.mergiraf.enable = true;
-    })
-  ]);
+      # Mergiraf configuration (Git merge conflict resolution tool)
+      (lib.mkIf (lib.hasAttr "mergiraf" config.programs) {
+        programs.mergiraf.enable = true;
+      })
+    ]);
 }

--- a/modules/home/applications/terminal/tools/git/default.nix
+++ b/modules/home/applications/terminal/tools/git/default.nix
@@ -1,4 +1,28 @@
-# Git configuration module
+# Git Configuration Module
+#
+# This module provides a comprehensive Git configuration with sensible defaults,
+# including signing, delta/difftastic integration, and common aliases.
+#
+# ## Features
+#
+# - Git signing with configurable SSH key
+# - Delta for beautiful diffs with syntax highlighting
+# - Difftastic for semantic diffing
+# - Common Git aliases and shell integration
+# - Git LFS support
+# - Maintenance tools (git-absorb, git-crypt, etc.)
+#
+# ## Example Configuration
+#
+# ```nix
+# {
+#   applications.terminal.tools.git = {
+#     enable = true;
+#     signingKey = "~/.ssh/id_ed25519";
+#     signByDefault = true;
+#   };
+# }
+# ```
 {
   config,
   lib,
@@ -10,16 +34,20 @@
 
   cfg = config.applications.terminal.tools.git;
 
-  # Import submodules
+  # Import Git aliases configuration
+  # See: ./aliases.nix for the complete list of aliases
   aliases = import ./aliases.nix {inherit lib;};
 
-  # Import git ignore patterns
+  # Import global Git ignore patterns
+  # These patterns will apply to all repositories unless overridden locally
   ignores = import ./git-ignore.nix;
 
-  # Import shell aliases
+  # Import Git-related shell aliases
+  # These aliases are added to the user's shell environment
   shell-aliases = import ./shell-aliases.nix {inherit config lib pkgs;};
 
-  # Common Git packages
+  # Git-related packages to be installed
+  # These provide additional Git functionality and tools
   gitPackages = with pkgs; [
     git-absorb
     git-crypt
@@ -31,7 +59,8 @@
     tig
   ];
 
-  # Git configuration
+  # Main Git configuration
+  # This defines the complete Git configuration that will be generated
   gitConfig = {
     enable = true;
     package = pkgs.gitFull;
@@ -42,24 +71,32 @@
     # Include git ignore patterns
     ignores = ignores;
 
-    # User configuration
+    # User identification
+    # These values typically come from the system's secrets management
     userName = inputs.secrets.username;
     userEmail = inputs.secrets.useremail;
 
+    # Enable Git maintenance for automatic repository optimization
     maintenance.enable = true;
 
+    # Delta configuration for beautiful diffs
+    # See: https://github.com/dandavison/delta
     delta.enable = true;
     delta.options.dark = true;
-    # FIXME: module should accept a mergable list be composable
+    # FIXME: This should be converted to use proper Nix types when the module is updated
+    # See: https://github.com/nix-community/home-manager/issues/2064
     delta.options.features = mkForce "decorations side-by-side navigate catppuccin-macchiato";
     delta.options.line-numbers = true;
     delta.options.navigate = true;
     delta.options.side-by-side = true;
 
+    # Difftastic configuration for semantic diffing
+    # See: https://github.com/Wilfred/difftastic
     difftastic.enableAsDifftool = true;
     difftastic.background = "dark";
     difftastic.display = "inline";
 
+    # Additional Git configuration
     extraConfig.branch.sort = "-committerdate";
     extraConfig.useHttpPath.enable = true;
     extraConfig.fetch.prune = true;
@@ -71,42 +108,77 @@
     extraConfig.rerere.enabled = true;
     extraConfig.rebase.autostash = true;
     extraConfig.safe.directory = [
-      "~/${inputs.secrets.username}/"
+      "/Users/${inputs.secrets.username}/"
       "/etc/nixos"
       "/etc/nix-darwin"
     ];
 
+    # Git signing configuration
     signing.key = cfg.signingKey;
     signing.format = "ssh";
     signing.signByDefault = cfg.signByDefault;
   };
 in {
   options.applications.terminal.tools.git = {
-    enable = mkEnableOption "Git configuration";
+    enable = mkEnableOption "Git configuration" // {
+      description = ''
+        Whether to enable the Git configuration module.
+        This includes Git itself, common tools, and configuration.
+      '';
+    };
 
-    # Configurable signing key
+    # SSH key used for commit/tag signing
+    #
+    # Type: null or string (path)
+    #
+    # Example:
+    #   signingKey = "~/.ssh/id_ed25519";
     signingKey = mkOption {
-      type = with lib.types; nullOr str;
+      type = with lib.types; nullOr (either str path);
       default = null;
-      description = "Path to the SSH private key for commit signing";
+      description = ''
+        Path to the SSH private key used for signing Git commits and tags.
+        Set to `null` to disable signing.
+      '';
       example = "~/.ssh/id_ed25519";
     };
 
-    # Whether to sign commits by default
+    # Whether to sign all commits by default
+    #
+    # Type: boolean
+    # Default: true
+    #
+    # Example:
+    #   signByDefault = true;  # Sign all commits by default
     signByDefault = mkOption {
       type = lib.types.bool;
       default = true;
-      description = "Whether to sign commits by default";
+      description = ''
+        Whether to automatically sign all Git commits by default.
+        When enabled, you won't need to use the -S flag with git commit.
+      '';
     };
   };
 
+  # Module implementation
   config = let
     cfg = config.applications.terminal.tools.git;
-  in
-    mkIf cfg.enable {
+  in lib.mkIf cfg.enable (lib.mkMerge [
+    # Base configuration
+    {
+      # Install Git packages
       home.packages = gitPackages;
+
+      # Main Git configuration
       programs.git = gitConfig;
-      programs.mergiraf.enable = true;
+
+      # Shell aliases for Git
       home.shellAliases = shell-aliases;
-    };
+    }
+
+    # Mergiraf configuration (Git merge conflict resolution tool)
+    (lib.mkIf (lib.hasAttr "mergiraf" config.programs) {
+      programs.mergiraf.enable = true;
+    })
+  ]);
 }

--- a/modules/home/applications/terminal/tools/git/default.nix
+++ b/modules/home/applications/terminal/tools/git/default.nix
@@ -98,6 +98,9 @@
 
     # Additional Git configuration
     extraConfig.branch.sort = "-committerdate";
+    
+    # Set default editor to nano
+    extraConfig.core.editor = "nano";
     extraConfig.useHttpPath.enable = true;
     extraConfig.fetch.prune = true;
     extraConfig.init.defaultBranch = "main";

--- a/modules/home/applications/terminal/tools/git/default.nix
+++ b/modules/home/applications/terminal/tools/git/default.nix
@@ -71,11 +71,11 @@
     extraConfig.rerere.enabled = true;
     extraConfig.rebase.autostash = true;
     extraConfig.safe.directory = [
-              "~/${inputs.secrets.username}/"
-              "/etc/nixos"
-              "/etc/nix-darwin"
-            ];
-    
+      "~/${inputs.secrets.username}/"
+      "/etc/nixos"
+      "/etc/nix-darwin"
+    ];
+
     signing.key = cfg.signingKey;
     signing.format = "ssh";
     signing.signByDefault = cfg.signByDefault;
@@ -83,7 +83,7 @@
 in {
   options.applications.terminal.tools.git = {
     enable = mkEnableOption "Git configuration";
-    
+
     # Configurable signing key
     signingKey = mkOption {
       type = with lib.types; nullOr str;
@@ -102,10 +102,11 @@ in {
 
   config = let
     cfg = config.applications.terminal.tools.git;
-  in mkIf cfg.enable {
-    home.packages = gitPackages;
-    programs.git = gitConfig;
-    programs.mergiraf.enable = true;
-    home.shellAliases = shell-aliases;
-  };
+  in
+    mkIf cfg.enable {
+      home.packages = gitPackages;
+      programs.git = gitConfig;
+      programs.mergiraf.enable = true;
+      home.shellAliases = shell-aliases;
+    };
 }

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -32,10 +32,8 @@ in {
   darwin.security.sops.defaultSopsFile = "${sopsFolder}/${inputs.secrets.username}.yaml";
   darwin.security.sops.age.keyFile = "/Users/${inputs.secrets.username}/.config/sops/age/keys.txt";
 
-  darwin.security.sops.secrets.github_ssh_private_key = {
-    key = "github_ssh_private_key";
-    path = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
-    mode = "0600";
-    owner = "${inputs.secrets.username}";
-  };
+  darwin.security.sops.secrets.github_ssh_private_key.key = "github_ssh_private_key";
+  darwin.security.sops.secrets.github_ssh_private_key.path = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
+  darwin.security.sops.secrets.github_ssh_private_key.mode = "0600";
+  darwin.security.sops.secrets.github_ssh_private_key.owner = "${inputs.secrets.username}";
 }


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul of the Git configuration module and related files, enhancing functionality, usability, and maintainability. Key changes include the addition of detailed Git configuration options, improved modularity, and updates to secrets handling.

### Git Configuration Enhancements:
* Added detailed configuration options for Git, including signing, Delta for syntax-highlighted diffs, Difftastic for semantic diffing, and common Git aliases. This includes support for setting a default editor, branch sorting, and Git LFS. (`modules/home/applications/terminal/tools/git/default.nix` - [[1]](diffhunk://#diff-061a99db20879a35f651f3ffa7885103de31ceafc3711c0dfd8634a385449bb5L34-R63) [[2]](diffhunk://#diff-061a99db20879a35f651f3ffa7885103de31ceafc3711c0dfd8634a385449bb5L45-R187)
* Introduced the ability to configure Git signing with an SSH key, with options for enabling signing by default and specifying the key path. (`modules/home/applications/terminal/tools/git/default.nix` - [modules/home/applications/terminal/tools/git/default.nixL45-R187](diffhunk://#diff-061a99db20879a35f651f3ffa7885103de31ceafc3711c0dfd8634a385449bb5L45-R187))
* Enhanced documentation within the module, including an example configuration and descriptions of features. (`modules/home/applications/terminal/tools/git/default.nix` - [modules/home/applications/terminal/tools/git/default.nixL1-R50](diffhunk://#diff-061a99db20879a35f651f3ffa7885103de31ceafc3711c0dfd8634a385449bb5L1-R50))

### Secrets and Key Management:
* Updated the handling of the Git SSH signing key to integrate with the user's secrets management system. (`homes/aarch64-darwin/aytordev@wang-lin/default.nix` - [homes/aarch64-darwin/aytordev@wang-lin/default.nixR40](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bR40))
* Refactored the SOPS configuration for the GitHub SSH private key to streamline the declaration format. (`supported-systems/aarch64-darwin/src/wang-lin/system/default.nix` - [supported-systems/aarch64-darwin/src/wang-lin/system/default.nixL35-R38](diffhunk://#diff-bc9905c66fbe88c05959b428d2a4283b89713269e648171a33c796685d07dd58L35-R38))