### PR TITLE
fest(modules/ssh): add ssh module

### DIFF
--- a/modules/darwin/applications/terminal/tools/ssh/default.nix
+++ b/modules/darwin/applications/terminal/tools/ssh/default.nix
@@ -1,0 +1,8 @@
+# Re-export the shared SSH module with Darwin-specific configurations
+{ libraries, ... }:
+
+{
+  imports = [
+    (libraries.relativeToRoot "modules/shared/applications/terminal/tools/ssh")
+  ];
+}

--- a/modules/shared/applications/terminal/tools/ssh/default.nix
+++ b/modules/shared/applications/terminal/tools/ssh/default.nix
@@ -1,0 +1,71 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib) mkEnableOption mkOption types;
+  
+  cfg = config.programs.terminal.tools.ssh;
+  
+in {
+  options.programs.terminal.tools.ssh = {
+    enable = mkEnableOption "SSH configuration and host management";
+    
+    port = mkOption {
+      type = types.port;
+      default = 2222;
+      description = "SSH port to use for local connections";
+    };
+    
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Additional SSH client configuration";
+    };
+    
+    knownHosts = mkOption {
+      type = types.attrsOf (types.submodule ({ name, ... }: {
+        options = {
+          hostNames = mkOption {
+            type = types.listOf types.str;
+            description = "List of host names for this known host entry";
+          };
+          
+          publicKey = mkOption {
+            type = types.str;
+            description = "Public key for the host";
+          };
+          
+          extraConfig = mkOption {
+            type = types.attrsOf types.str;
+            default = {};
+            description = "Additional configuration for the known host";
+          };
+        };
+      }));
+      default = {};
+      description = "Known hosts configuration";
+    };
+  };
+  
+  config = lib.mkIf cfg.enable {
+    programs.ssh = {
+      enable = true;
+      
+      extraConfig = ''
+        # Default SSH configuration
+        Host *
+          AddKeysToAgent yes
+          IdentitiesOnly yes
+          
+        # Local development
+        Host *.local
+          Port ${toString cfg.port}
+          
+        ${cfg.extraConfig}
+      '';
+      
+      knownHosts = lib.mapAttrs (name: host: {
+        inherit (host) hostNames publicKey;
+      } // host.extraConfig) cfg.knownHosts;
+    };
+  };
+}

--- a/modules/shared/applications/terminal/tools/ssh/default.nix
+++ b/modules/shared/applications/terminal/tools/ssh/default.nix
@@ -7,8 +7,6 @@ let
   
 in {
   options.programs.terminal.tools.ssh = {
-    enable = mkEnableOption "SSH configuration and host management";
-    
     port = mkOption {
       type = types.port;
       default = 2222;
@@ -46,7 +44,7 @@ in {
     };
   };
   
-  config = lib.mkIf cfg.enable {
+  config = {
     programs.ssh = {
       enable = true;
       

--- a/modules/shared/applications/terminal/tools/ssh/default.nix
+++ b/modules/shared/applications/terminal/tools/ssh/default.nix
@@ -3,10 +3,10 @@
 let
   inherit (lib) mkEnableOption mkOption types;
   
-  cfg = config.programs.terminal.tools.ssh;
+  cfg = config.applications.terminal.tools.ssh;
   
 in {
-  options.programs.terminal.tools.ssh = {
+  options.applications.terminal.tools.ssh = {
     port = mkOption {
       type = types.port;
       default = 2222;
@@ -45,9 +45,7 @@ in {
   };
   
   config = {
-    programs.ssh = {
-      enable = true;
-      
+    programs.ssh = {      
       extraConfig = ''
         # Default SSH configuration
         Host *

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -39,6 +39,10 @@
 
           ## Security
           "modules/darwin/security/sops/default.nix"
+
+          # Applications
+          ## Terminal tools
+          "modules/darwin/applications/terminal/tools/ssh/default.nix"
         ]
         ++ [
           inputs.sops-nix.darwinModules.sops

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -39,5 +39,5 @@ in {
 
   # SSH configuration
   applications.terminal.tools.ssh.knownHosts."github".hostNames = [ "github.com" ];
-  applications.terminal.tools.ssh.knownHosts."github".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";
+  applications.terminal.tools.ssh.knownHosts."github".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
 }

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -36,4 +36,8 @@ in {
   darwin.security.sops.secrets.github_ssh_private_key.path = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
   darwin.security.sops.secrets.github_ssh_private_key.mode = "0600";
   darwin.security.sops.secrets.github_ssh_private_key.owner = "${inputs.secrets.username}";
+
+  # SSH configuration
+  applications.terminal.tools.ssh.knownHosts."github".hostNames = [ "github.com" ];
+  applications.terminal.tools.ssh.knownHosts."github".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";
 }


### PR DESCRIPTION
This pull request introduces a new SSH configuration module with shared and Darwin-specific settings, integrates it into the system configuration, and adds a default known host entry for GitHub. Below is a summary of the most important changes:

### SSH Module Implementation:

* Created a shared SSH module in `modules/shared/applications/terminal/tools/ssh/default.nix` with configurable options for `port`, `extraConfig`, and `knownHosts`. It also defines default SSH client configurations and processes known hosts entries dynamically.

* Added a Darwin-specific wrapper for the shared SSH module in `modules/darwin/applications/terminal/tools/ssh/default.nix`, re-exporting it with Darwin-compatible configurations.

### System Integration:

* Included the new SSH module in the Darwin system configuration by adding its path to the list of modules in `supported-systems/aarch64-darwin/src/wang-lin/default.nix`.

* Configured a known host entry for GitHub in `supported-systems/aarch64-darwin/src/wang-lin/system/default.nix`, specifying its hostname and public key.