### PR TITLE
feat(security/sudo): add sudo darwin modules

### DIFF
--- a/modules/darwin/applications/terminal/tools/ssh/default.nix
+++ b/modules/darwin/applications/terminal/tools/ssh/default.nix
@@ -1,7 +1,5 @@
 # Re-export the shared SSH module with Darwin-specific configurations
-{ libraries, ... }:
-
-{
+{libraries, ...}: {
   imports = [
     (libraries.relativeToRoot "modules/shared/applications/terminal/tools/ssh")
   ];

--- a/modules/darwin/security/sudo/default.nix
+++ b/modules/darwin/security/sudo/default.nix
@@ -1,0 +1,52 @@
+# Sudo Configuration Module for Darwin
+#
+# This module configures sudo with Touch ID authentication and custom settings
+# for macOS systems. It enables secure authentication with Touch ID and sets
+# a reasonable default timeout for sudo credentials.
+#
+# Version: 1.0.0
+# Last Updated: 2025-07-08
+{
+  config,
+  lib,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.darwin.security.sudo;
+in {
+  ####################################
+  # Module Options
+  ####################################
+  options.darwin.security.sudo = {
+    enable = mkEnableOption "sudo configuration with Touch ID support";
+  };
+
+  ####################################
+  # Module Implementation
+  ####################################
+  config = mkIf cfg.enable {
+    security = {
+      # Configure PAM for sudo with Touch ID support
+      pam.services = {
+        sudo_local = {
+          reattach = true;
+          touchIdAuth = true;
+        };
+      };
+
+      # Set sudo timeout to 30 minutes
+      sudo.extraConfig = ''
+        # Set sudo timeout to 30 minutes (1800 seconds)
+        Defaults timestamp_timeout=30
+        
+        # Preserve environment variables (adjust as needed)
+        Defaults env_keep += "HOME"
+        Defaults env_keep += "PATH"
+        Defaults env_keep += "SSH_AUTH_SOCK"
+      '';
+    };
+  };
+}

--- a/modules/darwin/security/sudo/default.nix
+++ b/modules/darwin/security/sudo/default.nix
@@ -11,10 +11,7 @@
   lib,
   ...
 }:
-
-with lib;
-
-let
+with lib; let
   cfg = config.darwin.security.sudo;
 in {
   ####################################
@@ -41,7 +38,7 @@ in {
       sudo.extraConfig = ''
         # Set sudo timeout to 30 minutes (1800 seconds)
         Defaults timestamp_timeout=30
-        
+
         # Preserve environment variables (adjust as needed)
         Defaults env_keep += "HOME"
         Defaults env_keep += "PATH"

--- a/modules/darwin/services/openssh/default.nix
+++ b/modules/darwin/services/openssh/default.nix
@@ -1,10 +1,12 @@
-{ config, lib, pkgs, ... }:
-
-let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
   inherit (lib) mkEnableOption mkIf mkOption types;
-  
+
   cfg = config.darwin.services.openssh;
-  
 in {
   options.darwin.services.openssh = {
     extraConfig = mkOption {
@@ -25,12 +27,12 @@ in {
 
   config = {
     # Add OpenSSH package to system packages
-    environment.systemPackages = [ pkgs.openssh ];
-    
+    environment.systemPackages = [pkgs.openssh];
+
     # Configure the OpenSSH service
     services.openssh = {
       enable = true;
-      
+
       # Append any additional configuration provided by the user
       extraConfig = cfg.extraConfig;
     };

--- a/modules/shared/applications/terminal/tools/ssh/default.nix
+++ b/modules/shared/applications/terminal/tools/ssh/default.nix
@@ -1,10 +1,11 @@
-{ config, lib, ... }:
-
-let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib) mkEnableOption mkOption types;
-  
+
   cfg = config.applications.terminal.tools.ssh;
-  
 in {
   options.applications.terminal.tools.ssh = {
     port = mkOption {
@@ -12,26 +13,26 @@ in {
       default = 2222;
       description = "SSH port to use for local connections";
     };
-    
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";
       description = "Additional SSH client configuration";
     };
-    
+
     knownHosts = mkOption {
-      type = types.attrsOf (types.submodule ({ name, ... }: {
+      type = types.attrsOf (types.submodule ({name, ...}: {
         options = {
           hostNames = mkOption {
             type = types.listOf types.str;
             description = "List of host names for this known host entry";
           };
-          
+
           publicKey = mkOption {
             type = types.str;
             description = "Public key for the host";
           };
-          
+
           extraConfig = mkOption {
             type = types.attrsOf types.str;
             default = {};
@@ -43,25 +44,28 @@ in {
       description = "Known hosts configuration";
     };
   };
-  
+
   config = {
-    programs.ssh = {      
+    programs.ssh = {
       extraConfig = ''
         # Default SSH configuration
         Host *
           AddKeysToAgent yes
           IdentitiesOnly yes
-          
+
         # Local development
         Host *.local
           Port ${toString cfg.port}
-          
+
         ${cfg.extraConfig}
       '';
-      
-      knownHosts = lib.mapAttrs (name: host: {
-        inherit (host) hostNames publicKey;
-      } // host.extraConfig) cfg.knownHosts;
+
+      knownHosts = lib.mapAttrs (name: host:
+        {
+          inherit (host) hostNames publicKey;
+        }
+        // host.extraConfig)
+      cfg.knownHosts;
     };
   };
 }

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -39,6 +39,7 @@
 
           ## Security
           "modules/darwin/security/sops/default.nix"
+          "modules/darwin/security/sudo/default.nix"
 
           ## Services
           "modules/darwin/services/openssh/default.nix"

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -40,4 +40,7 @@ in {
   # SSH configuration
   applications.terminal.tools.ssh.knownHosts."github".hostNames = [ "github.com" ];
   applications.terminal.tools.ssh.knownHosts."github".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
+
+  # Sudo configuration
+  darwin.security.sudo.enable = true;
 }

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -38,7 +38,7 @@ in {
   darwin.security.sops.secrets.github_ssh_private_key.owner = "${inputs.secrets.username}";
 
   # SSH configuration
-  applications.terminal.tools.ssh.knownHosts."github".hostNames = [ "github.com" ];
+  applications.terminal.tools.ssh.knownHosts."github".hostNames = ["github.com"];
   applications.terminal.tools.ssh.knownHosts."github".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
 
   # Sudo configuration


### PR DESCRIPTION
This pull request introduces several updates to the Darwin NixOS configuration, focusing on improving SSH and sudo configurations for macOS systems. The most significant changes include adding a new sudo configuration module with Touch ID support, refactoring existing SSH-related modules for consistency, and enabling the new sudo configuration in a supported system.

### Sudo Configuration Updates:
* Added a new `sudo` module for Darwin systems (`modules/darwin/security/sudo/default.nix`), which supports Touch ID authentication, sets a default sudo timeout of 30 minutes, and allows environment variable preservation.
* Enabled the new `sudo` configuration in the `aarch64-darwin` supported system (`supported-systems/aarch64-darwin/src/wang-lin/system/default.nix`).
* Included the `sudo` module in the list of security modules for the `aarch64-darwin` system (`supported-systems/aarch64-darwin/src/wang-lin/default.nix`).

### SSH Configuration Refactoring:
* Refactored the SSH module for Darwin-specific configurations to improve readability and maintainability by modifying the structure of `modules/darwin/applications/terminal/tools/ssh/default.nix`.
* Updated the shared SSH module to use a consistent syntax for defining `knownHosts` mappings (`modules/shared/applications/terminal/tools/ssh/default.nix`).

### General Codebase Improvements:
* Standardized the syntax for module definitions across various files, including `modules/darwin/services/openssh/default.nix` and `modules/shared/applications/terminal/tools/ssh/default.nix`. [[1]](diffhunk://#diff-91417a7f863f036f90296f9b76fc8f706e86cf4916f6fb8300a8250da18fdb64L1-L7) [[2]](diffhunk://#diff-d4d8b8fc397d99c0fc90925f3f4794a25bc48ea75509037cb2f0eac7e746372dL1-L7)