### PR TITLE
feat(module/zsh): add zsh configuration with starship

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -44,6 +44,7 @@
 
   # Enable my starship configuration
   applications.terminal.tools.starship.enable = true;
+  applications.terminal.tools.starship.enableZshIntegration = true;
 
   # Example configurations (commented out for reference):
   # ====================================================

--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -39,6 +39,9 @@
   applications.terminal.tools.git.enable = true;
   applications.terminal.tools.git.signingKey = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
 
+  # Enable my zsh configuration
+  applications.terminal.shells.zsh.enable = true;
+
   # Example configurations (commented out for reference):
   # ====================================================
   #

--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -42,6 +42,9 @@
   # Enable my zsh configuration
   applications.terminal.shells.zsh.enable = true;
 
+  # Enable my starship configuration
+  applications.terminal.tools.starship.enable = true;
+
   # Example configurations (commented out for reference):
   # ====================================================
   #

--- a/modules/home/applications/terminal/shells/zsh/default.nix
+++ b/modules/home/applications/terminal/shells/zsh/default.nix
@@ -6,12 +6,11 @@
 }:
 with lib; let
   cfg = config.applications.terminal.shells.zsh;
-  
+
   # XDG Base Directory paths
   xdgConfigHome = "${config.xdg.configHome}";
   xdgDataHome = "${config.xdg.dataHome}";
   xdgCacheHome = "${config.xdg.cacheHome}";
-  
 in {
   options.applications.terminal.shells.zsh = {
     enable = mkEnableOption "Z shell with useful defaults";
@@ -21,29 +20,29 @@ in {
     {
       programs.zsh = {
         enable = true;
-        
+
         # XDG Base Directory compliance
         dotDir = ".config/zsh";
-        
+
         # Set ZDOTDIR to ensure all zsh files are in XDG config
         envExtra = ''
           # Set ZDOTDIR if not already set
           export ZDOTDIR="${xdgConfigHome}/zsh"
-          
+
           # Ensure ZDOTDIR exists
           if [ ! -d "$ZDOTDIR" ]; then
             mkdir -p "$ZDOTDIR"
           fi
-          
+
           # Set ZSH data directories according to XDG spec
           export ZSH="${xdgDataHome}/zsh"
           export ZSH_CACHE_DIR="${xdgCacheHome}/zsh"
-          
+
           # Create necessary directories
           mkdir -p "$ZSH"
           mkdir -p "$ZSH_CACHE_DIR"
         '';
-        
+
         # History settings with XDG compliance
         history = {
           path = "${xdgDataHome}/zsh/history";
@@ -53,7 +52,7 @@ in {
           expireDuplicatesFirst = true;
           extended = true;
         };
-        
+
         # Completion cache in XDG cache directory
         completionInit = ''
           autoload -Uz compinit
@@ -62,14 +61,15 @@ in {
           compinit -d ${xdgCacheHome}/zsh/zcompdump
         '';
       };
-      
+
       # Required packages
       home.packages = with pkgs; [
         zsh
       ];
-      
+
       # Create necessary XDG directories
-      xdg.configFile."zsh".source = lib.mkIf (config.programs.zsh.dotDir == ".config/zsh") 
+      xdg.configFile."zsh".source =
+        lib.mkIf (config.programs.zsh.dotDir == ".config/zsh")
         (pkgs.runCommand "zsh-config-dir" {} ''
           mkdir -p $out
           # Add any default zsh configuration files here if needed

--- a/modules/home/applications/terminal/shells/zsh/default.nix
+++ b/modules/home/applications/terminal/shells/zsh/default.nix
@@ -1,8 +1,10 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
-let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
   cfg = config.applications.terminal.shells.zsh;
 in {
   options.applications.terminal.shells.zsh = {
@@ -13,7 +15,7 @@ in {
     programs.zsh = {
       enable = true;
     };
-    
+
     # Required packages
     home.packages = with pkgs; [
       zsh

--- a/modules/home/applications/terminal/shells/zsh/default.nix
+++ b/modules/home/applications/terminal/shells/zsh/default.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.applications.terminal.shells.zsh;
+in {
+  options.applications.terminal.shells.zsh = {
+    enable = mkEnableOption "Z shell with useful defaults";
+  };
+
+  config = mkIf cfg.enable {
+    programs.zsh = {
+      enable = true;
+    };
+    
+    # Required packages
+    home.packages = with pkgs; [
+      zsh
+    ];
+  };
+}

--- a/modules/home/applications/terminal/shells/zsh/default.nix
+++ b/modules/home/applications/terminal/shells/zsh/default.nix
@@ -6,19 +6,74 @@
 }:
 with lib; let
   cfg = config.applications.terminal.shells.zsh;
+  
+  # XDG Base Directory paths
+  xdgConfigHome = "${config.xdg.configHome}";
+  xdgDataHome = "${config.xdg.dataHome}";
+  xdgCacheHome = "${config.xdg.cacheHome}";
+  
 in {
   options.applications.terminal.shells.zsh = {
     enable = mkEnableOption "Z shell with useful defaults";
   };
 
-  config = mkIf cfg.enable {
-    programs.zsh = {
-      enable = true;
-    };
-
-    # Required packages
-    home.packages = with pkgs; [
-      zsh
-    ];
-  };
+  config = mkIf cfg.enable (mkMerge [
+    {
+      programs.zsh = {
+        enable = true;
+        
+        # XDG Base Directory compliance
+        dotDir = ".config/zsh";
+        
+        # Set ZDOTDIR to ensure all zsh files are in XDG config
+        envExtra = ''
+          # Set ZDOTDIR if not already set
+          export ZDOTDIR="${xdgConfigHome}/zsh"
+          
+          # Ensure ZDOTDIR exists
+          if [ ! -d "$ZDOTDIR" ]; then
+            mkdir -p "$ZDOTDIR"
+          fi
+          
+          # Set ZSH data directories according to XDG spec
+          export ZSH="${xdgDataHome}/zsh"
+          export ZSH_CACHE_DIR="${xdgCacheHome}/zsh"
+          
+          # Create necessary directories
+          mkdir -p "$ZSH"
+          mkdir -p "$ZSH_CACHE_DIR"
+        '';
+        
+        # History settings with XDG compliance
+        history = {
+          path = "${xdgDataHome}/zsh/history";
+          save = 10000;
+          size = 10000;
+          share = true;
+          expireDuplicatesFirst = true;
+          extended = true;
+        };
+        
+        # Completion cache in XDG cache directory
+        completionInit = ''
+          autoload -Uz compinit
+          zstyle ':completion:*' cache-path ${xdgCacheHome}/zsh/zcompcache
+          zmodload zsh/complist
+          compinit -d ${xdgCacheHome}/zsh/zcompdump
+        '';
+      };
+      
+      # Required packages
+      home.packages = with pkgs; [
+        zsh
+      ];
+      
+      # Create necessary XDG directories
+      xdg.configFile."zsh".source = lib.mkIf (config.programs.zsh.dotDir == ".config/zsh") 
+        (pkgs.runCommand "zsh-config-dir" {} ''
+          mkdir -p $out
+          # Add any default zsh configuration files here if needed
+        '');
+    }
+  ]);
 }

--- a/modules/home/applications/terminal/tools/starship/README.md
+++ b/modules/home/applications/terminal/tools/starship/README.md
@@ -1,0 +1,50 @@
+# Starship Module
+
+A simple and efficient module for integrating the [Starship](https://starship.rs/) prompt with your shell.
+
+## Features
+
+- Easy integration with ZSH
+- Customizable prompt configuration
+- Git status integration
+- Fast and lightweight
+- Follows XDG Base Directory specification
+
+## Configuration
+
+Enable the module in your user configuration:
+
+```nix
+applications.terminal.tools.starship = {
+  enable = true;
+  enableZshIntegration = true;  # Enabled by default
+  
+  # Customize your prompt
+  settings = {
+    # Your custom Starship configuration
+    # See: https://starship.rs/config/
+  };
+};
+```
+
+## Default Configuration
+
+The module comes with a sensible default configuration that includes:
+
+- Clean prompt format with username, hostname, directory, and Git status
+- Color-coded Git status indicators
+- Truncated paths in the prompt
+- Disabled package version display for better performance
+
+## Dependencies
+
+- `starship` - The Starship prompt
+- `zsh` (optional) - For ZSH integration
+
+## Integration
+
+The module automatically initializes Starship in your ZSH configuration when `enableZshIntegration` is set to `true`.
+
+## Customization
+
+You can customize the prompt by modifying the `settings` attribute. Refer to the [Starship documentation](https://starship.rs/config/) for all available options.

--- a/modules/home/applications/terminal/tools/starship/default.nix
+++ b/modules/home/applications/terminal/tools/starship/default.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.applications.terminal.tools.starship;
+in {
+  options.applications.terminal.tools.starship = {
+    enable = mkEnableOption "Starship prompt";
+    
+    enableZshIntegration = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to enable Starship integration with ZSH";
+    };
+    
+    settings = mkOption {
+      type = types.attrs;
+      default = {};
+      description = "Starship configuration options";
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      home.packages = [ pkgs.starship ];
+      
+      xdg.configFile."starship.toml".source = 
+        pkgs.writeText "starship.toml" (builtins.toJSON cfg.settings);
+    }
+    
+    (mkIf (cfg.enable && cfg.enableZshIntegration) {
+      programs.zsh.initExtra = ''
+        # Initialize Starship
+        eval "$(starship init zsh)"
+      '';
+    })
+  ]);
+}

--- a/modules/home/applications/terminal/tools/starship/default.nix
+++ b/modules/home/applications/terminal/tools/starship/default.nix
@@ -4,8 +4,18 @@
   pkgs,
   ...
 }:
-with lib; let
+
+with lib;
+
+let
   cfg = config.applications.terminal.tools.starship;
+
+  # Import modules
+  nordTheme = import ./themes/nord.nix { inherit lib; };
+  osModule = import ./modules/os.nix { inherit lib; };
+  gitModule = import ./modules/git.nix { inherit lib; };
+  languagesModule = import ./modules/languages.nix { inherit lib; };
+  shellModule = import ./modules/shell.nix { inherit lib; };
 
   # XDG Base Directory paths
   xdgConfigHome = "${config.xdg.configHome}";
@@ -15,6 +25,39 @@ with lib; let
   # Starship configuration paths
   starshipConfigDir = "${xdgConfigHome}/starship";
   starshipConfigFile = "${starshipConfigDir}/config.toml";
+
+  # Base configuration
+  baseConfig = {
+    "$schema" = "https://starship.rs/config-schema.json";
+    format = """
+      [╭](bold overlay1)$username\
+      $directory\
+      $git_branch\
+      $git_status\
+      $c\
+      $rust\
+      $golang\
+      $nodejs\
+      $php\
+      $java\
+      $kotlin\
+      $haskell\
+      $python\
+      $lua\
+      $docker_context\
+      $line_break$character""";
+  };
+
+  # Merge all configurations using foldl and recursiveUpdate
+  mergedConfig = lib.foldl lib.recursiveUpdate {} [
+    baseConfig
+    nordTheme
+    osModule
+    gitModule
+    languagesModule
+    shellModule
+  ];
+
 in {
   options.applications.terminal.tools.starship = {
     enable = mkEnableOption "Starship prompt";
@@ -27,7 +70,7 @@ in {
 
     settings = mkOption {
       type = types.attrs;
-      default = {};
+      default = mergedConfig;
       description = "Starship configuration options";
     };
   };

--- a/modules/home/applications/terminal/tools/starship/default.nix
+++ b/modules/home/applications/terminal/tools/starship/default.nix
@@ -30,7 +30,7 @@ in {
     }
     
     (mkIf (cfg.enable && cfg.enableZshIntegration) {
-      programs.zsh.initExtra = ''
+      programs.zsh.initContent = ''
         # Initialize Starship
         eval "$(starship init zsh)"
       '';

--- a/modules/home/applications/terminal/tools/starship/default.nix
+++ b/modules/home/applications/terminal/tools/starship/default.nix
@@ -1,29 +1,30 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
-let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
   cfg = config.applications.terminal.tools.starship;
-  
+
   # XDG Base Directory paths
   xdgConfigHome = "${config.xdg.configHome}";
   xdgDataHome = "${config.xdg.dataHome}";
   xdgCacheHome = "${config.xdg.cacheHome}";
-  
+
   # Starship configuration paths
   starshipConfigDir = "${xdgConfigHome}/starship";
   starshipConfigFile = "${starshipConfigDir}/config.toml";
-  
 in {
   options.applications.terminal.tools.starship = {
     enable = mkEnableOption "Starship prompt";
-    
+
     enableZshIntegration = mkOption {
       type = types.bool;
       default = true;
       description = "Whether to enable Starship integration with ZSH";
     };
-    
+
     settings = mkOption {
       type = types.attrs;
       default = {};
@@ -33,34 +34,34 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
-      home.packages = [ pkgs.starship ];
-      
+      home.packages = [pkgs.starship];
+
       # Create Starship configuration directory and files
       xdg.configFile = {
         # Main configuration file
-        "starship/config.toml".source = 
+        "starship/config.toml".source =
           pkgs.writeText "starship-config.toml" (builtins.toJSON cfg.settings);
-        
+
         # Directory for additional configuration files
         "starship/modules".source = lib.mkForce (pkgs.runCommand "starship-modules-dir" {} ''
           mkdir -p $out
           # Add any additional module configurations here
         '');
       };
-      
+
       # Set STARSHIP_CACHE and other environment variables according to XDG spec
       home.sessionVariables = {
         STARSHIP_CACHE = "${xdgCacheHome}/starship";
         STARSHIP_CONFIG = "${starshipConfigFile}";
         STARSHIP_CONFIG_DIR = "${starshipConfigDir}";
       };
-      
+
       # Create cache directory
       xdg.cacheFile."starship".source = lib.mkForce (pkgs.runCommand "starship-cache-dir" {} ''
         mkdir -p $out
       '');
     }
-    
+
     (mkIf (cfg.enable && cfg.enableZshIntegration) {
       programs.zsh.initContent = ''
         # Initialize Starship with XDG compliance
@@ -68,14 +69,14 @@ in {
           export STARSHIP_CONFIG="${starshipConfigFile}"
           export STARSHIP_CONFIG_DIR="${starshipConfigDir}"
           export STARSHIP_CACHE="${xdgCacheHome}/starship"
-          
+
           # Ensure directories exist
           for dir in "$STARSHIP_CACHE" "$STARSHIP_CONFIG_DIR/modules"; do
             if [ ! -d "$dir" ]; then
               mkdir -p "$dir"
             fi
           done
-          
+
           # Initialize starship
           eval "$(${pkgs.starship}/bin/starship init zsh --print-full-init)"
         fi

--- a/modules/home/applications/terminal/tools/starship/default.nix
+++ b/modules/home/applications/terminal/tools/starship/default.nix
@@ -4,6 +4,16 @@ with lib;
 
 let
   cfg = config.applications.terminal.tools.starship;
+  
+  # XDG Base Directory paths
+  xdgConfigHome = "${config.xdg.configHome}";
+  xdgDataHome = "${config.xdg.dataHome}";
+  xdgCacheHome = "${config.xdg.cacheHome}";
+  
+  # Starship configuration paths
+  starshipConfigDir = "${xdgConfigHome}/starship";
+  starshipConfigFile = "${starshipConfigDir}/config.toml";
+  
 in {
   options.applications.terminal.tools.starship = {
     enable = mkEnableOption "Starship prompt";
@@ -25,14 +35,50 @@ in {
     {
       home.packages = [ pkgs.starship ];
       
-      xdg.configFile."starship.toml".source = 
-        pkgs.writeText "starship.toml" (builtins.toJSON cfg.settings);
+      # Create Starship configuration directory and files
+      xdg.configFile = {
+        # Main configuration file
+        "starship/config.toml".source = 
+          pkgs.writeText "starship-config.toml" (builtins.toJSON cfg.settings);
+        
+        # Directory for additional configuration files
+        "starship/modules".source = lib.mkForce (pkgs.runCommand "starship-modules-dir" {} ''
+          mkdir -p $out
+          # Add any additional module configurations here
+        '');
+      };
+      
+      # Set STARSHIP_CACHE and other environment variables according to XDG spec
+      home.sessionVariables = {
+        STARSHIP_CACHE = "${xdgCacheHome}/starship";
+        STARSHIP_CONFIG = "${starshipConfigFile}";
+        STARSHIP_CONFIG_DIR = "${starshipConfigDir}";
+      };
+      
+      # Create cache directory
+      xdg.cacheFile."starship".source = lib.mkForce (pkgs.runCommand "starship-cache-dir" {} ''
+        mkdir -p $out
+      '');
     }
     
     (mkIf (cfg.enable && cfg.enableZshIntegration) {
       programs.zsh.initContent = ''
-        # Initialize Starship
-        eval "$(starship init zsh)"
+        # Initialize Starship with XDG compliance
+        if [ -n "$commands[starship]" ]; then
+          export STARSHIP_CONFIG="${starshipConfigFile}"
+          export STARSHIP_CONFIG_DIR="${starshipConfigDir}"
+          export STARSHIP_CACHE="${xdgCacheHome}/starship"
+          
+          # Ensure directories exist
+          for dir in "$STARSHIP_CACHE" "$STARSHIP_CONFIG_DIR/modules"; do
+            if [ ! -d "$dir" ]; then
+              mkdir -p "$dir"
+            fi
+          done
+          
+          # Initialize starship
+          eval "$(${pkgs.starship}/bin/starship init zsh --print-full-init)"
+        fi
       '';
     })
   ]);

--- a/modules/home/applications/terminal/tools/starship/default.nix
+++ b/modules/home/applications/terminal/tools/starship/default.nix
@@ -15,7 +15,7 @@ let
   osModule = import ./modules/os.nix { inherit lib; };
   gitModule = import ./modules/git.nix { inherit lib; };
   languagesModule = import ./modules/languages.nix { inherit lib; };
-  shellModule = import ./modules/shell.nix { inherit lib; };
+  shellModule = import ./modules/shell-module.nix { inherit lib; };
 
   # XDG Base Directory paths
   xdgConfigHome = "${config.xdg.configHome}";

--- a/modules/home/applications/terminal/tools/starship/modules/git.nix
+++ b/modules/home/applications/terminal/tools/starship/modules/git.nix
@@ -1,0 +1,14 @@
+{ lib }:
+
+{
+  git_branch = {
+    symbol = "";
+    style = "fg:teal";
+    format = "[[ $symbol $branch ](fg:green)]($style)";
+  };
+
+  git_status = {
+    style = "fg:teal";
+    format = "[[($all_status$ahead_behind )](fg:green)]($style)";
+  };
+}

--- a/modules/home/applications/terminal/tools/starship/modules/languages.nix
+++ b/modules/home/applications/terminal/tools/starship/modules/languages.nix
@@ -1,0 +1,66 @@
+{ lib }:
+
+let
+  langFormat = symbol: "[[ $symbol( $version) ](fg:teal)](fg:teal)";
+in
+{
+  nodejs = {
+    symbol = "";
+    style = "fg:teal";
+    format = langFormat "";
+  };
+
+  c = {
+    symbol = " ";
+    style = "fg:teal";
+    format = langFormat "";
+  };
+
+  rust = {
+    symbol = "";
+    style = "fg:teal";
+    format = langFormat "";
+  };
+
+  golang = {
+    symbol = "";
+    style = "fg:teal";
+    format = langFormat "";
+  };
+
+  php = {
+    symbol = "";
+    style = "fg:teal";
+    format = langFormat "";
+  };
+
+  java = {
+    symbol = " ";
+    style = "fg:teal";
+    format = langFormat "";
+  };
+
+  kotlin = {
+    symbol = "";
+    style = "fg:teal";
+    format = langFormat "";
+  };
+
+  haskell = {
+    symbol = "";
+    style = "fg:teal";
+    format = langFormat "";
+  };
+
+  python = {
+    symbol = "";
+    style = "fg:teal";
+    format = langFormat "";
+  };
+
+  lua = {
+    symbol = "󰢱";
+    style = "fg:teal";
+    format = langFormat "󰢱";
+  };
+}

--- a/modules/home/applications/terminal/tools/starship/modules/os.nix
+++ b/modules/home/applications/terminal/tools/starship/modules/os.nix
@@ -1,0 +1,43 @@
+{ lib }:
+
+{
+  os = {
+    disabled = false;
+    style = "fg:text";
+    symbols = {
+      Windows = "󰍲";
+      Ubuntu = "󰕈";
+      SUSE = "";
+      Raspbian = "󰐿";
+      Mint = "󰣭";
+      Macos = "";
+      Manjaro = "";
+      Linux = "󰌽";
+      Gentoo = "󰣨";
+      Fedora = "󰣛";
+      Alpine = "";
+      Amazon = "";
+      Android = "";
+      Arch = "󰣇";
+      Artix = "󰣇";
+      CentOS = "";
+      Debian = "󰣚";
+      Redhat = "󱄛";
+      RedHatEnterprise = "󱄛";
+    };
+  };
+
+  username = {
+    show_always = true;
+    style_user = "fg:blue";
+    style_root = "fg:blue";
+    format = "[ $user ]($style)";
+  };
+
+  localip = {
+    ssh_only = false;
+    style = "fg:surface0";
+    format = "[ $localipv4 ]($style)";
+    disabled = false;
+  };
+}

--- a/modules/home/applications/terminal/tools/starship/modules/shell-module.nix
+++ b/modules/home/applications/terminal/tools/starship/modules/shell-module.nix
@@ -1,0 +1,41 @@
+{ lib }:
+
+{
+  directory = {
+    style = "fg:peach";
+    format = "[ $path ]($style)";
+    truncation_length = 3;
+    truncation_symbol = "…/";
+    substitutions = {
+      "Documents" = "󰈙 ";
+      "Downloads" = " ";
+      "Music" = "󰝚 ";
+      "Pictures" = " ";
+      "Developer" = "󰲋 ";
+    };
+  };
+
+  docker_context = {
+    symbol = "";
+    style = "fg:mantle";
+    format = "[[ $symbol( $context) ](fg:color_bg3)]($style)";
+  };
+
+  time = {
+    disabled = false;
+    time_format = "%R";
+    style = "fg:peach";
+    format = "[[  $time ](fg:purple)]($style)";
+  };
+
+  line_break = {
+    disabled = false;
+  };
+
+  character = {
+    format = ''
+      [╰─$symbol](fg:overlay1) '';
+    success_symbol = "[](fg:bold text)";
+    error_symbol = "[×](fg:bold red)";
+  };
+}

--- a/modules/home/applications/terminal/tools/starship/themes/nord.nix
+++ b/modules/home/applications/terminal/tools/starship/themes/nord.nix
@@ -1,0 +1,34 @@
+{ lib }:
+
+{
+  palette = "nord";
+
+  palettes.nord = {
+    rosewater = "#f0c674";
+    flamingo = "#cc6666";
+    pink = "#b294bb";
+    orange = "#de935f";
+    red = "#cc6666";
+    maroon = "#a54242";
+    peach = "#d08770";
+    yellow = "#f0c674";
+    green = "#8abeb7";
+    teal = "#8abeb7";
+    sky = "#81a2be";
+    sapphire = "#81a2be";
+    blue = "#5e81ac";
+    lavender = "#b48ead";
+    text = "#d8dee9";
+    subtext1 = "#e5e9f0";
+    subtext0 = "#eceff4";
+    overlay2 = "#4c566a";
+    overlay1 = "#434c5e";
+    overlay0 = "#3b4252";
+    surface2 = "#2e3440";
+    surface1 = "#2e3440";
+    surface0 = "#2e3440";
+    base = "#2e3440";
+    mantle = "#3b4252";
+    crust = "#434c5e";
+  };
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -70,6 +70,8 @@
         # Applications
         ## Terminal tools
         "modules/home/applications/terminal/tools/git/default.nix"
+        ## Shells
+        "modules/home/applications/terminal/shells/zsh/default.nix"
       ])
       ++ (map libraries.relativeToRoot [
         # Host-specific user configuration

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -70,6 +70,7 @@
         # Applications
         ## Terminal tools
         "modules/home/applications/terminal/tools/git/default.nix"
+        "modules/home/applications/terminal/tools/starship/default.nix"
         ## Shells
         "modules/home/applications/terminal/shells/zsh/default.nix"
       ])


### PR DESCRIPTION
This pull request introduces a comprehensive set of changes to enable and configure ZSH and Starship prompt integration within a Nix-based environment. The changes include enabling ZSH with XDG Base Directory compliance, adding a Starship module with customizable configuration, and defining modular configurations for themes, Git, languages, and shell-specific settings.

### ZSH Configuration Enhancements:
* Added a module to enable ZSH (`applications.terminal.shells.zsh`) with XDG Base Directory compliance, ensuring that configuration, data, and cache files are stored in appropriate directories. This includes history settings and completion cache management.

### Starship Prompt Integration:
* Introduced a Starship module (`applications.terminal.tools.starship`) with options for enabling ZSH integration, customizable prompt settings, and XDG Base Directory compliance. Default configurations include Git status, truncated paths, and modular support for languages and themes.
* Added a README file for the Starship module, documenting its features, configuration, and customization options.

### Modular Configurations for Starship:
* Defined modular configurations for Git (`modules/git.nix`), languages (`modules/languages.nix`), operating systems (`modules/os.nix`), and shell-specific settings (`modules/shell-module.nix`). These modules provide customizable symbols, styles, and formats for the Starship prompt. [[1]](diffhunk://#diff-31cb30cad7af43fe82182c9985f0c76edb79f96dfd0af66ad2e0815c3cd6737cR1-R14) [[2]](diffhunk://#diff-008070f39d768d47e2532de4ffdfb65764738a4e96fc9757ecf87ed9b0bef23eR1-R66) [[3]](diffhunk://#diff-faf634cc95d14d1f67154765ae8195ffe220916165fd4109e3e2911a3b54ba9eR1-R43) [[4]](diffhunk://#diff-a96a5b648767573e5a339068c6f707ac417bbbc7c41e2753834f670ef861b308R1-R41)
* Added a Nord theme module (`themes/nord.nix`) with a predefined color palette for consistent styling in the Starship prompt.

### Integration with Existing Configuration:
* Updated the user configuration to enable ZSH and Starship prompt integration by default, linking the respective modules in the system configuration. [[1]](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bR42-R48) [[2]](diffhunk://#diff-80fa091607f0022f5215bf9e69c8ac7093fd2b605ccd9364cff9be483b24a3a5R73-R75)