### PR TITLE
fix(darwin): switch font installation to use Nix packages

### DIFF
--- a/modules/darwin/system/fonts/default.nix
+++ b/modules/darwin/system/fonts/default.nix
@@ -75,8 +75,8 @@ in {
         else 0;
     };
 
-    # Install fonts through homebrew for better macOS integration
-    # homebrew.casks = [ "font-hack-nerd-font" "font-fira-code" ];
+    # Install fonts directly from Nix packages
+    fonts.packages = lib.optionals (cfg != null && cfg.fonts != null) cfg.fonts;
 
     # Add assertions for font smoothing configuration
     assertions =


### PR DESCRIPTION
This pull request modifies the font installation process in the `modules/darwin/system/fonts/default.nix` file to improve macOS integration by switching from Homebrew to Nix packages.

### Changes to font installation:

* Replaced the commented-out Homebrew-based font installation (`homebrew.casks`) with a configuration to install fonts directly from Nix packages using the `fonts.packages` attribute. This change leverages `lib.optionals` to conditionally include fonts based on the configuration provided (`cfg.fonts`).