### PR TITLE
feat(starship): update prompt configuration and modules

### DIFF
--- a/modules/home/applications/terminal/tools/starship/default.nix
+++ b/modules/home/applications/terminal/tools/starship/default.nix
@@ -4,18 +4,15 @@
   pkgs,
   ...
 }:
-
-with lib;
-
-let
+with lib; let
   cfg = config.applications.terminal.tools.starship;
 
   # Import modules
-  nordTheme = import ./themes/nord.nix { inherit lib; };
-  osModule = import ./modules/os.nix { inherit lib; };
-  gitModule = import ./modules/git.nix { inherit lib; };
-  languagesModule = import ./modules/languages.nix { inherit lib; };
-  shellModule = import ./modules/shell-module.nix { inherit lib; };
+  nordTheme = import ./themes/nord.nix {inherit lib;};
+  osModule = import ./modules/os.nix {inherit lib;};
+  gitModule = import ./modules/git.nix {inherit lib;};
+  languagesModule = import ./modules/languages.nix {inherit lib;};
+  shellModule = import ./modules/shell-module.nix {inherit lib;};
 
   # XDG Base Directory paths
   xdgConfigHome = "${config.xdg.configHome}";
@@ -30,24 +27,58 @@ let
   # Base configuration
   baseConfig = {
     "$schema" = "https://starship.rs/config-schema.json";
-    format = ''
-      [╭](bold overlay1)'' + "$username" + ''
-      '' + "$directory" + ''
-      '' + "$git_branch" + ''
-      '' + "$git_status" + ''
-      '' + "$c" + ''
-      '' + "$rust" + ''
-      '' + "$golang" + ''
-      '' + "$nodejs" + ''
-      '' + "$php" + ''
-      '' + "$java" + ''
-      '' + "$kotlin" + ''
-      '' + "$haskell" + ''
-      '' + "$python" + ''
-      '' + "$lua" + ''
-      '' + "$docker_context" + ''
-      '' + "$line_break" + "$character" + ''
-    '';
+    format =
+      ''
+        [╭](bold overlay1)''
+      + "$username"
+      + ''
+      ''
+      + "$directory"
+      + ''
+      ''
+      + "$git_branch"
+      + ''
+      ''
+      + "$git_status"
+      + ''
+      ''
+      + "$c"
+      + ''
+      ''
+      + "$rust"
+      + ''
+      ''
+      + "$golang"
+      + ''
+      ''
+      + "$nodejs"
+      + ''
+      ''
+      + "$php"
+      + ''
+      ''
+      + "$java"
+      + ''
+      ''
+      + "$kotlin"
+      + ''
+      ''
+      + "$haskell"
+      + ''
+      ''
+      + "$python"
+      + ''
+      ''
+      + "$lua"
+      + ''
+      ''
+      + "$docker_context"
+      + ''
+      ''
+      + "$line_break"
+      + "$character"
+      + ''
+      '';
   };
 
   # Merge all configurations using foldl and recursiveUpdate
@@ -59,7 +90,6 @@ let
     languagesModule
     shellModule
   ];
-
 in {
   options.applications.terminal.tools.starship = {
     enable = mkEnableOption "Starship prompt";
@@ -101,7 +131,7 @@ in {
       # Create Starship configuration directory and files
       xdg.configFile = {
         # Main configuration file - using TOML format
-        "starship/config.toml".source = (pkgs.formats.toml { }).generate "starship-config" cfg.settings;
+        "starship/config.toml".source = (pkgs.formats.toml {}).generate "starship-config" cfg.settings;
 
         # Directory for additional configuration files
         "starship/modules".source = lib.mkForce (pkgs.runCommand "starship-modules-dir" {} ''

--- a/modules/home/applications/terminal/tools/starship/modules/git.nix
+++ b/modules/home/applications/terminal/tools/starship/modules/git.nix
@@ -1,6 +1,4 @@
-{ lib }:
-
-{
+{lib}: {
   git_branch = {
     symbol = "";
     style = "fg:teal";

--- a/modules/home/applications/terminal/tools/starship/modules/languages.nix
+++ b/modules/home/applications/terminal/tools/starship/modules/languages.nix
@@ -1,9 +1,6 @@
-{ lib }:
-
-let
+{lib}: let
   langFormat = symbol: "[[ $symbol( $version) ](fg:teal)](fg:teal)";
-in
-{
+in {
   nodejs = {
     symbol = "";
     style = "fg:teal";

--- a/modules/home/applications/terminal/tools/starship/modules/os.nix
+++ b/modules/home/applications/terminal/tools/starship/modules/os.nix
@@ -1,6 +1,4 @@
-{ lib }:
-
-{
+{lib}: {
   os = {
     disabled = false;
     style = "fg:text";

--- a/modules/home/applications/terminal/tools/starship/modules/shell-module.nix
+++ b/modules/home/applications/terminal/tools/starship/modules/shell-module.nix
@@ -1,6 +1,4 @@
-{ lib }:
-
-{
+{lib}: {
   directory = {
     style = "fg:peach";
     format = "[ $path ]($style)";
@@ -35,7 +33,7 @@
   character = {
     format = ''
       [╰─$symbol](fg:overlay1) '';
-    success_symbol = "[](fg:bold text)";
-    error_symbol = "[×](fg:bold red)";
+    success_symbol = "[❯](fg:bold text)";
+    error_symbol = "[✗](fg:bold red)";
   };
 }

--- a/modules/home/applications/terminal/tools/starship/themes/nord.nix
+++ b/modules/home/applications/terminal/tools/starship/themes/nord.nix
@@ -1,6 +1,4 @@
-{ lib }:
-
-{
+{lib}: {
   palette = "nord";
 
   palettes.nord = {


### PR DESCRIPTION
This pull request introduces several changes to the Starship prompt configuration and its modules. The updates primarily focus on improving code consistency, formatting, and style adjustments across multiple files. The most significant changes include reformatting the `format` field in the base configuration, simplifying module definitions by removing unnecessary line breaks, and updating symbols for success and error states in the shell module.

### Code consistency and formatting improvements:

* [`modules/home/applications/terminal/tools/starship/default.nix`](diffhunk://#diff-796ae656a48784fae274afee9fcb66a18ecc18d62182cc5b0e748ac83a862c04L33-R80): Reorganized the `format` field in the base configuration for improved readability by adding line breaks between concatenated strings.
* [`modules/home/applications/terminal/tools/starship/default.nix`](diffhunk://#diff-796ae656a48784fae274afee9fcb66a18ecc18d62182cc5b0e748ac83a862c04L7-R7): Removed redundant line breaks around `with lib` and `in` statements to streamline the code. [[1]](diffhunk://#diff-796ae656a48784fae274afee9fcb66a18ecc18d62182cc5b0e748ac83a862c04L7-R7) [[2]](diffhunk://#diff-796ae656a48784fae274afee9fcb66a18ecc18d62182cc5b0e748ac83a862c04L62)

### Module definition simplifications:

* [`modules/home/applications/terminal/tools/starship/modules/git.nix`](diffhunk://#diff-31cb30cad7af43fe82182c9985f0c76edb79f96dfd0af66ad2e0815c3cd6737cL1-R1): Simplified the module definition by removing unnecessary line breaks around the `{ lib }` argument.
* [`modules/home/applications/terminal/tools/starship/modules/languages.nix`](diffhunk://#diff-008070f39d768d47e2532de4ffdfb65764738a4e96fc9757ecf87ed9b0bef23eL1-R3): Simplified the module definition by removing redundant line breaks and reformatting the `let` block.
* Similar simplifications applied to `os.nix`, `shell-module.nix`, and `themes/nord.nix` for consistency. [[1]](diffhunk://#diff-faf634cc95d14d1f67154765ae8195ffe220916165fd4109e3e2911a3b54ba9eL1-R1) [[2]](diffhunk://#diff-a96a5b648767573e5a339068c6f707ac417bbbc7c41e2753834f670ef861b308L1-R1) [[3]](diffhunk://#diff-b14d15f3fc618fa4a934c3ac2eec706a9add29beb228bb778c32ae3d139e565fL1-R1)

### Style adjustments:

* [`modules/home/applications/terminal/tools/starship/modules/shell-module.nix`](diffhunk://#diff-a96a5b648767573e5a339068c6f707ac417bbbc7c41e2753834f670ef861b308L38-R37): Updated the symbols for success (`❯`) and error (`✗`) states in the `character` configuration for improved clarity and aesthetics.