### PR TITLE
feat(starship): update shell module symbols and add Nix indicator

### DIFF
--- a/modules/home/applications/terminal/tools/starship/modules/shell-module.nix
+++ b/modules/home/applications/terminal/tools/starship/modules/shell-module.nix
@@ -34,6 +34,6 @@
     format = ''
       [╰─$symbol](fg:overlay1) '';
     success_symbol = "[❯](fg:bold text)";
-    error_symbol = "[✗](fg:bold red)";
+    error_symbol = "[×](fg:bold red)";
   };
 }


### PR DESCRIPTION
This pull request makes a minor change to the `shell-module.nix` file, updating the `error_symbol` for better consistency and readability.

* [`modules/home/applications/terminal/tools/starship/modules/shell-module.nix`](diffhunk://#diff-a96a5b648767573e5a339068c6f707ac417bbbc7c41e2753834f670ef861b308L37-R37): Changed the `error_symbol` from `[✗](fg:bold red)` to `[×](fg:bold red)`.