### PR TITLE
feat(modules/bat): add cat alias for bat in bash via conf.d

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -64,6 +64,9 @@
   # Enable my zoxide configuration
   applications.terminal.tools.zoxide.enable = true;
 
+  # Enable my bat configuration
+  applications.terminal.tools.bat.enable = true;
+
   # Example configurations (commented out for reference):
   # ====================================================
   #

--- a/modules/home/applications/terminal/tools/bat/default.nix
+++ b/modules/home/applications/terminal/tools/bat/default.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) getExe mkIf;
+  cfg = config.applications.terminal.tools.bat;
+in
+{
+  options.applications.terminal.tools.bat = {
+    enable = lib.mkEnableOption "bat";
+  };
+
+  config = mkIf cfg.enable {
+    programs.bat = {
+      enable = true;
+      config = {
+        style = "auto,header-filesize";
+      };
+      extraPackages = with pkgs.bat-extras; [
+        batdiff
+        batgrep
+        batman
+        batpipe
+        batwatch
+        prettybat
+      ];
+    };
+
+    home.shellAliases = {
+      cat = "${getExe pkgs.bat} --style=auto";
+    };
+
+    home.file.".config/bash/conf.d/bat.sh".text = ''
+      alias cat="${pkgs.bat}/bin/bat --style=auto"
+    '';
+  };
+}

--- a/modules/home/applications/terminal/tools/bat/default.nix
+++ b/modules/home/applications/terminal/tools/bat/default.nix
@@ -1,9 +1,12 @@
-{ config, lib, pkgs, ... }:
-let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
   inherit (lib) getExe mkIf;
   cfg = config.applications.terminal.tools.bat;
-in
-{
+in {
   options.applications.terminal.tools.bat = {
     enable = lib.mkEnableOption "bat";
   };

--- a/modules/home/applications/terminal/tools/starship/default.nix
+++ b/modules/home/applications/terminal/tools/starship/default.nix
@@ -280,7 +280,7 @@ in {
             # Initialize starship
             eval "$(starship init bash --print-full-init)"
           fi
-        '';  # Suppress error if starship fails
+        ''; # Suppress error if starship fails
       };
     })
   ]);

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -74,7 +74,7 @@
         "modules/home/applications/terminal/tools/fzf/default.nix"
         "modules/home/applications/terminal/tools/zoxide/default.nix"
         "modules/home/applications/terminal/tools/bat/default.nix"
-        
+
         ## Shells
         "modules/home/applications/terminal/shells/zsh/default.nix"
         "modules/home/applications/terminal/shells/bash/default.nix"

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -73,6 +73,8 @@
         "modules/home/applications/terminal/tools/starship/default.nix"
         "modules/home/applications/terminal/tools/fzf/default.nix"
         "modules/home/applications/terminal/tools/zoxide/default.nix"
+        "modules/home/applications/terminal/tools/bat/default.nix"
+        
         ## Shells
         "modules/home/applications/terminal/shells/zsh/default.nix"
         "modules/home/applications/terminal/shells/bash/default.nix"


### PR DESCRIPTION
This pull request introduces support for configuring the `bat` terminal tool in the Nix-based configuration system. The changes add a new module for `bat`, enable its configuration in the user's setup, and include it in the list of supported tools.

### Addition of `bat` tool configuration:

* [`modules/home/applications/terminal/tools/bat/default.nix`](diffhunk://#diff-d56f310f0a234ac1b386fd0ec8db0ab28b368abaf49d7040abf66783e58b4929R1-R35): Added a new module for configuring the `bat` tool. This includes enabling `bat`, setting its style to `auto,header-filesize`, adding extra packages (`batdiff`, `batgrep`, etc.), and defining shell aliases for `cat` to use `bat`. It also creates a `.bash` configuration file with an alias for `cat`.

### Integration into existing configuration:

* [`homes/aarch64-darwin/aytordev@wang-lin/default.nix`](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bR67-R69): Enabled the `bat` tool in the user's terminal configuration.
* [`supported-systems/aarch64-darwin/src/wang-lin/default.nix`](diffhunk://#diff-80fa091607f0022f5215bf9e69c8ac7093fd2b605ccd9364cff9be483b24a3a5R76-R77): Added the `bat` module to the list of supported terminal tools.