### PR TITLE
feat(terminal/tools): add bottom monitor

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -74,6 +74,9 @@
   applications.terminal.tools.atuin.enableZshIntegration = true;
   applications.terminal.tools.atuin.enableNushellIntegration = true;
 
+  # Enable my bottom configuration
+  applications.terminal.tools.bottom.enable = true;
+
   # Example configurations (commented out for reference):
   # ====================================================
   #

--- a/modules/home/applications/terminal/tools/bottom/default.nix
+++ b/modules/home/applications/terminal/tools/bottom/default.nix
@@ -17,7 +17,7 @@ in {
 
     programs.bottom = {
       enable = true;
-      package = bottom;
+      package = pkgs.bottom;
 
       settings = {
         flags.group_processes = true;

--- a/modules/home/applications/terminal/tools/bottom/default.nix
+++ b/modules/home/applications/terminal/tools/bottom/default.nix
@@ -12,6 +12,9 @@ in {
   };
 
   config = mkIf cfg.enable {
+    # Ensure the bottom package is installed
+    home.packages = with pkgs; [ bottom ];
+
     programs.bottom = {
       enable = true;
       package = pkgs.bottom;
@@ -41,5 +44,11 @@ in {
         ];
       };
     };
+
+    # Add bash configuration
+    home.file.".config/bash/conf.d/bottom.sh".text = ''
+      # Use btm as a modern alternative to htop
+      alias htop="${pkgs.bottom}/bin/btm"
+    '';
   };
 }

--- a/modules/home/applications/terminal/tools/bottom/default.nix
+++ b/modules/home/applications/terminal/tools/bottom/default.nix
@@ -1,0 +1,45 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib) mkIf;
+  cfg = config.applications.terminal.tools.bottom;
+in {
+  options.applications.terminal.tools.bottom = {
+    enable = lib.mkEnableOption "bottom";
+  };
+
+  config = mkIf cfg.enable {
+    programs.bottom = {
+      enable = true;
+      package = pkgs.bottom;
+
+      settings = {
+        flags.group_processes = true;
+
+        row = [
+          {
+            ratio = 3;
+            child = [
+              {type = "cpu";}
+              {type = "mem";}
+              {type = "net";}
+            ];
+          }
+          {
+            ratio = 3;
+            child = [
+              {
+                type = "proc";
+                ratio = 1;
+                default = true;
+              }
+            ];
+          }
+        ];
+      };
+    };
+  };
+}

--- a/modules/home/applications/terminal/tools/bottom/default.nix
+++ b/modules/home/applications/terminal/tools/bottom/default.nix
@@ -17,7 +17,7 @@ in {
 
     programs.bottom = {
       enable = true;
-      package = pkgs.bottom;
+      package = bottom;
 
       settings = {
         flags.group_processes = true;

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -75,6 +75,7 @@
         "modules/home/applications/terminal/tools/zoxide/default.nix"
         "modules/home/applications/terminal/tools/bat/default.nix"
         "modules/home/applications/terminal/tools/atuin/default.nix"
+        "modules/home/applications/terminal/tools/bottom/default.nix"
 
         ## Shells
         "modules/home/applications/terminal/shells/zsh/default.nix"


### PR DESCRIPTION
This pull request introduces support for configuring and enabling the `bottom` terminal tool, a modern system monitoring tool, in the Nix-based configuration. The changes include adding the necessary module for `bottom`, enabling its integration, and updating related configurations.

### Support for `bottom` terminal tool:

* [`homes/aarch64-darwin/aytordev@wang-lin/default.nix`](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bR77-R79): Added an option to enable the `bottom` tool in the terminal applications configuration.
* [`modules/home/applications/terminal/tools/bottom/default.nix`](diffhunk://#diff-aeb69a5834465fe3553b760e74f1c2662cede1e9330d54b19e40e39e50a9b655R1-R54): Introduced a new module for `bottom` with options to enable the tool, install the package, configure its settings (e.g., grouping processes, layout customization), and add a Bash alias for using `btm` as an alternative to `htop`.

### Configuration updates:

* [`supported-systems/aarch64-darwin/src/wang-lin/default.nix`](diffhunk://#diff-80fa091607f0022f5215bf9e69c8ac7093fd2b605ccd9364cff9be483b24a3a5R78): Included the new `bottom` module in the list of supported terminal tools.