### PR TITLE
feat(terminal/tools): add top monitor

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -77,6 +77,9 @@
   # Enable my bottom configuration
   applications.terminal.tools.bottom.enable = true;
 
+  # Enable my btop configuration
+  applications.terminal.tools.btop.enable = true;
+
   # Example configurations (commented out for reference):
   # ====================================================
   #

--- a/modules/home/applications/terminal/shells/bash/default.nix
+++ b/modules/home/applications/terminal/shells/bash/default.nix
@@ -3,7 +3,8 @@
   lib,
   pkgs,
   ...
-}: with lib; let
+}:
+with lib; let
   cfg = config.applications.terminal.shells.bash;
   xdgConfigHome = "${config.xdg.configHome}";
   xdgDataHome = "${config.xdg.dataHome}";
@@ -72,8 +73,8 @@
       # Just ensure the symlink exists (handled by home.activation)
       :
     fi
-  ''; in {
-
+  '';
+in {
   options.applications.terminal.shells.bash = {
     enable = mkEnableOption "Bash shell with useful defaults";
   };

--- a/modules/home/applications/terminal/tools/atuin/default.nix
+++ b/modules/home/applications/terminal/tools/atuin/default.nix
@@ -1,10 +1,12 @@
-{ config, lib, ... }:
-let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib) mkIf mkEnableOption optionalAttrs;
 
   cfg = config.applications.terminal.tools.atuin;
-in
-{
+in {
   options.applications.terminal.tools.atuin = {
     enable = mkEnableOption "atuin";
     enableDebug = mkEnableOption "atuin daemon debug logging";

--- a/modules/home/applications/terminal/tools/bottom/default.nix
+++ b/modules/home/applications/terminal/tools/bottom/default.nix
@@ -13,7 +13,7 @@ in {
 
   config = mkIf cfg.enable {
     # Ensure the bottom package is installed
-    home.packages = with pkgs; [ bottom ];
+    home.packages = with pkgs; [bottom];
 
     programs.bottom = {
       enable = true;

--- a/modules/home/applications/terminal/tools/btop/default.nix
+++ b/modules/home/applications/terminal/tools/btop/default.nix
@@ -1,18 +1,19 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
-let
-  cfg = config.applications.terminal.tools.btop;
-in
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.applications.terminal.tools.btop;
+in {
   options.applications.terminal.tools.btop = {
     enable = mkEnableOption "btop - A resource monitor that shows usage and stats for processor, memory, disks, network and processes";
   };
 
   config = mkIf cfg.enable {
     # Ensure the btop package is installed
-    home.packages = with pkgs; [ btop ];
+    home.packages = with pkgs; [btop];
 
     programs.btop = {
       enable = true;

--- a/modules/home/applications/terminal/tools/btop/default.nix
+++ b/modules/home/applications/terminal/tools/btop/default.nix
@@ -1,0 +1,87 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.applications.terminal.tools.btop;
+in
+{
+  options.applications.terminal.tools.btop = {
+    enable = mkEnableOption "btop - A resource monitor that shows usage and stats for processor, memory, disks, network and processes";
+  };
+
+  config = mkIf cfg.enable {
+    # Ensure the btop package is installed
+    home.packages = with pkgs; [ btop ];
+
+    programs.btop = {
+      enable = true;
+      package = pkgs.btop;
+      settings = {
+        theme_background = true;
+        truecolor = true;
+        force_tty = false;
+        presets = "cpu:1:default,proc:0:default cpu:0:default,mem:0:default,net:0:default cpu:0:block,net:0:tty";
+        vim_keys = false;
+        rounded_corners = true;
+        graph_symbol = "braille";
+        graph_symbol_cpu = "default";
+        graph_symbol_mem = "default";
+        graph_symbol_net = "default";
+        graph_symbol_proc = "default";
+        shown_boxes = "proc net mem cpu";
+        update_ms = 2000;
+        proc_sorting = "cpu direct";
+        proc_reversed = false;
+        proc_tree = false;
+        proc_colors = true;
+        proc_gradient = true;
+        proc_per_core = true;
+        proc_mem_bytes = true;
+        proc_cpu_graphs = true;
+        proc_info_smaps = false;
+        proc_left = false;
+        proc_filter_kernel = false;
+        cpu_graph_upper = "total";
+        cpu_graph_lower = "total";
+        cpu_invert_lower = true;
+        cpu_single_graph = false;
+        cpu_bottom = false;
+        show_uptime = true;
+        check_temp = true;
+        cpu_sensor = "Auto";
+        show_coretemp = true;
+        cpu_core_map = "";
+        temp_scale = "celsius";
+        base_10_sizes = false;
+        show_cpu_freq = true;
+        clock_format = "%X";
+        background_update = true;
+        custom_cpu_name = "";
+        disks_filter = "";
+        mem_graphs = true;
+        mem_below_net = false;
+        zfs_arc_cached = true;
+        show_swap = true;
+        swap_disk = true;
+        show_disks = true;
+        only_physical = true;
+        use_fstab = true;
+        zfs_hide_datasets = false;
+        disk_free_priv = false;
+        show_io_stat = true;
+        io_mode = false;
+        io_graph_combined = false;
+        io_graph_speeds = "";
+        net_download = 100;
+        net_upload = 100;
+        net_auto = true;
+        net_sync = false;
+        net_iface = "";
+        show_battery = true;
+        selected_battery = "Auto";
+        log_level = "WARNING";
+      };
+    };
+  };
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -76,6 +76,7 @@
         "modules/home/applications/terminal/tools/bat/default.nix"
         "modules/home/applications/terminal/tools/atuin/default.nix"
         "modules/home/applications/terminal/tools/bottom/default.nix"
+        "modules/home/applications/terminal/tools/btop/default.nix"
 
         ## Shells
         "modules/home/applications/terminal/shells/zsh/default.nix"


### PR DESCRIPTION
This pull request introduces configurations for the `btop` tool, improves code consistency across multiple files, and adds support for a new module. Below is a summary of the most important changes:

### New Feature: `btop` Configuration

* Added a new configuration for the `btop` resource monitor, including detailed settings and options, in `modules/home/applications/terminal/tools/btop/default.nix`. This ensures `btop` is installed and configured with custom preferences such as themes, update intervals, and graph symbols.
* Enabled the `btop` configuration in the `homes/aarch64-darwin/aytordev@wang-lin/default.nix` file.
* Registered the `btop` module in the list of supported tools in `supported-systems/aarch64-darwin/src/wang-lin/default.nix`.

### Code Consistency Improvements

* Updated the function argument formatting in `modules/home/applications/terminal/shells/bash/default.nix` and `modules/home/applications/terminal/tools/atuin/default.nix` to use a consistent style for attribute sets. [[1]](diffhunk://#diff-d00dbf044c40c38e46624fe5bd5e0a23819cf84591bdb95402fbfb1116660dd5L6-R7) [[2]](diffhunk://#diff-d00dbf044c40c38e46624fe5bd5e0a23819cf84591bdb95402fbfb1116660dd5L75-R77) [[3]](diffhunk://#diff-c3ca396e506c9a5ca6ec539b99a459d981062a2d8943240b7c6d5e1cbb07b215L1-R9)