### PR TITLE
feat(terminal/tools): add carapace monitor

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -80,6 +80,9 @@
   # Enable my btop configuration
   applications.terminal.tools.btop.enable = true;
 
+  # Enable carapace for shell completions
+  applications.terminal.tools.carapace.enable = true;
+
   # Example configurations (commented out for reference):
   # ====================================================
   #

--- a/modules/home/applications/terminal/shells/bash/default.nix
+++ b/modules/home/applications/terminal/shells/bash/default.nix
@@ -47,20 +47,7 @@ with lib; let
     # Source system-wide bashrc if it exists
     [ -f /etc/bashrc ] && . /etc/bashrc
 
-    # Enable programmable completion (Nix/XDG first, fallback to system)
-    if ! shopt -oq posix; then
-      if [ -f ${pkgs.bash-completion}/share/bash-completion/bash_completion ]; then
-        . ${pkgs.bash-completion}/share/bash-completion/bash_completion
-      elif [ -f /usr/share/bash-completion/bash_completion ]; then
-        . /usr/share/bash-completion/bash_completion
-      elif [ -f /etc/bash_completion ]; then
-        . /etc/bash_completion
-      fi
-    fi
-
-    # Load nix completions
-    [ -f ${pkgs.nix-bash-completions}/share/bash-completion/completions/nix ] &&
-      . ${pkgs.nix-bash-completions}/share/bash-completion/completions/nix
+    # Completions are handled by carapace
 
     # Source additional configs from conf.d if they exist
     # Load configurations in order:
@@ -82,8 +69,6 @@ in {
   config = mkIf cfg.enable (mkMerge [
     {
       home.packages = with pkgs; [
-        bash-completion
-        nix-bash-completions
         bash
       ];
 

--- a/modules/home/applications/terminal/tools/carapace/default.nix
+++ b/modules/home/applications/terminal/tools/carapace/default.nix
@@ -20,17 +20,36 @@ in {
       enable = true;
       enableBashIntegration = true;
       enableFishIntegration = true;
-      enableZshIntegration = false; # Prefer fzf-tab plugin
+      enableZshIntegration = true; # Enable Zsh integration for completions
       enableNushellIntegration = true;
     };
 
+    # Zsh integration with fzf-tab compatibility
     programs.zsh.initContent = ''
       # Carapace shell integration
-      export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense'
+      if [ -n "$ZSH_VERSION" ]; then
+        export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense'
+        
+        # Only initialize carapace if we're in an interactive shell
+        if [[ $- == *i* ]]; then
+          # Source carapace completions if available
+          if command -v carapace >/dev/null 2>&1; then
+            # Use eval to properly handle the output of carapace _carapace
+            eval "$(carapace _carapace | sed 's/^compdef /compdef -e /')"
+          fi
+        fi
+      fi
       
       # Custom completion formatting
       zstyle ':completion:*' format '%F{8}%d%f'
       zstyle ':completion:*:git:*' group-order 'main commands' 'alias commands' 'external commands'
+    '';
+
+    # Add carapace to bash configuration
+    home.file.".config/bash/conf.d/carapace.sh".text = ''
+      # Carapace shell integration for bash
+      export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense' # optional
+      source <(carapace _carapace)
     '';
   };
 }

--- a/modules/home/applications/terminal/tools/carapace/default.nix
+++ b/modules/home/applications/terminal/tools/carapace/default.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.applications.terminal.tools.carapace;
+in {
+  options.applications.terminal.tools.carapace = {
+    enable = mkEnableOption "carapace - multi-shell command argument completer";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      carapace
+    ];
+
+    programs.carapace = {
+      enable = true;
+      enableBashIntegration = true;
+      enableFishIntegration = true;
+      enableZshIntegration = false; # Prefer fzf-tab plugin
+      enableNushellIntegration = true;
+    };
+
+    programs.zsh.initContent = ''
+      # Carapace shell integration
+      export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense'
+      
+      # Custom completion formatting
+      zstyle ':completion:*' format '%F{8}%d%f'
+      zstyle ':completion:*:git:*' group-order 'main commands' 'alias commands' 'external commands'
+    '';
+  };
+}

--- a/modules/home/applications/terminal/tools/carapace/default.nix
+++ b/modules/home/applications/terminal/tools/carapace/default.nix
@@ -29,7 +29,7 @@ in {
       # Carapace shell integration
       if [ -n "$ZSH_VERSION" ]; then
         export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense'
-        
+
         # Only initialize carapace if we're in an interactive shell
         if [[ $- == *i* ]]; then
           # Source carapace completions if available
@@ -39,7 +39,7 @@ in {
           fi
         fi
       fi
-      
+
       # Custom completion formatting
       zstyle ':completion:*' format '%F{8}%d%f'
       zstyle ':completion:*:git:*' group-order 'main commands' 'alias commands' 'external commands'

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -77,6 +77,7 @@
         "modules/home/applications/terminal/tools/atuin/default.nix"
         "modules/home/applications/terminal/tools/bottom/default.nix"
         "modules/home/applications/terminal/tools/btop/default.nix"
+        "modules/home/applications/terminal/tools/carapace/default.nix"
 
         ## Shells
         "modules/home/applications/terminal/shells/zsh/default.nix"


### PR DESCRIPTION
This pull request introduces the integration of `carapace`, a multi-shell command argument completer, into the terminal tools configuration. It replaces the previous bash completions setup and adds support for multiple shells, including Bash, Zsh, Fish, and Nushell. Below are the key changes grouped by theme:

### Carapace Integration:

* Added a new configuration module for `carapace`, enabling its use across multiple shells (Bash, Zsh, Fish, Nushell) and providing custom completion formatting for Zsh. (`modules/home/applications/terminal/tools/carapace/default.nix`)

* Enabled `carapace` in the default configuration for terminal tools, replacing the previous bash completions setup. (`homes/aarch64-darwin/aytordev@wang-lin/default.nix`)

### Removal of Legacy Bash Completions:

* Removed the legacy bash completions setup, including `bash-completion` and `nix-bash-completions`, as these are now handled by `carapace`. (`modules/home/applications/terminal/shells/bash/default.nix`) [[1]](diffhunk://#diff-d00dbf044c40c38e46624fe5bd5e0a23819cf84591bdb95402fbfb1116660dd5L50-R50) [[2]](diffhunk://#diff-d00dbf044c40c38e46624fe5bd5e0a23819cf84591bdb95402fbfb1116660dd5L85-L86)

### System Configuration Updates:

* Updated the supported systems configuration to include the new `carapace` module in the list of terminal tools. (`supported-systems/aarch64-darwin/src/wang-lin/default.nix`)