### PR TITLE
fix(ssh): ssh module fixes

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -91,27 +91,22 @@
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ"
   ];
     
-  # Known hosts configuration
+  # Known hosts configuration with enhanced options
   applications.terminal.tools.ssh.knownHosts = {
     github = {
       hostNames = ["github.com"];
-      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
-    };
-  };
-  
-  # Host-specific configurations
-  applications.terminal.tools.ssh.matchBlocks = {
-    # GitHub configuration
-    "github.com" = {
       user = "git";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
       identityFile = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
       identitiesOnly = true;
+      port = 22;
     };
   };
     
   # Additional SSH configuration
   applications.terminal.tools.ssh.extraConfig = ''
-    # Add any additional SSH configuration here
+    # Additional SSH configuration can be added here
+    # These settings will override the defaults
   '';
 
   # Example configurations (commented out for reference):

--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -86,11 +86,6 @@
   # SSH configuration
   applications.terminal.tools.ssh.enable = true;
     
-  # Add your public keys here (they'll be added to ~/.ssh/authorized_keys)
-  applications.terminal.tools.ssh.authorizedKeys = [
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ"
-  ];
-    
   # Known hosts configuration with enhanced options
   applications.terminal.tools.ssh.knownHosts = {
     github = {

--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -85,7 +85,7 @@
 
   # SSH configuration
   applications.terminal.tools.ssh.enable = true;
-    
+
   # Known hosts configuration with enhanced options
   applications.terminal.tools.ssh.knownHosts = {
     github = {
@@ -97,7 +97,7 @@
       port = 22;
     };
   };
-    
+
   # Additional SSH configuration
   applications.terminal.tools.ssh.extraConfig = ''
     # Additional SSH configuration can be added here

--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -83,6 +83,37 @@
   # Enable carapace for shell completions
   applications.terminal.tools.carapace.enable = true;
 
+  # SSH configuration
+  applications.terminal.tools.ssh.enable = true;
+    
+  # Add your public keys here (they'll be added to ~/.ssh/authorized_keys)
+  applications.terminal.tools.ssh.authorizedKeys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ"
+  ];
+    
+  # Known hosts configuration
+  applications.terminal.tools.ssh.knownHosts = {
+    github = {
+      hostNames = ["github.com"];
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
+    };
+  };
+  
+  # Host-specific configurations
+  applications.terminal.tools.ssh.matchBlocks = {
+    # GitHub configuration
+    "github.com" = {
+      user = "git";
+      identityFile = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
+      identitiesOnly = true;
+    };
+  };
+    
+  # Additional SSH configuration
+  applications.terminal.tools.ssh.extraConfig = ''
+    # Add any additional SSH configuration here
+  '';
+
   # Example configurations (commented out for reference):
   # ====================================================
   #

--- a/modules/home/applications/terminal/tools/ssh/default.nix
+++ b/modules/home/applications/terminal/tools/ssh/default.nix
@@ -120,7 +120,9 @@ in {
             identityFile = host.identityFile or null;
             identitiesOnly = host.identitiesOnly or null;
             extraOptions = lib.optionalAttrs (host ? publicKey) {
-              HostKey = host.publicKey;
+              # Use HostKeyAlias for proper host key verification
+              HostKeyAlias = lib.head host.hostNames;
+              # The public key will be added to known_hosts by Home Manager
             } // (host.extraOptions or {});
           };
         }) cfg.knownHosts)

--- a/modules/home/applications/terminal/tools/ssh/default.nix
+++ b/modules/home/applications/terminal/tools/ssh/default.nix
@@ -1,0 +1,110 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib) mkEnableOption mkOption types;
+
+  cfg = config.applications.terminal.tools.ssh;
+in {
+  options.applications.terminal.tools.ssh = {
+    enable = mkEnableOption "SSH configuration";
+    
+    port = mkOption {
+      type = types.port;
+      default = 2222;
+      description = "Default SSH port for local development hosts (*.local)";
+    };
+
+    authorizedKeys = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = "List of authorized public keys added to ~/.ssh/authorized_keys";
+    };
+
+    knownHosts = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          hostNames = mkOption {
+            type = types.listOf types.str;
+            description = "List of host names for this known host entry";
+          };
+          publicKey = mkOption {
+            type = types.str;
+            description = "Public key for the host";
+          };
+        };
+      });
+      default = {};
+      description = "Known hosts configuration";
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Additional SSH configuration";
+    };
+
+    matchBlocks = mkOption {
+      type = types.attrsOf types.attrs;
+      default = {};
+      description = "SSH match blocks for specific hosts";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.ssh = {
+      enable = true;
+      
+      # Combine default configuration, known hosts, and user-provided config
+      extraConfig = ''
+        # Default SSH configuration
+        Host *
+          AddKeysToAgent yes
+          IdentitiesOnly yes
+          ForwardAgent no
+          Compression no
+          ServerAliveInterval 0
+          ServerAliveCountMax 3
+          HashKnownHosts no
+          UserKnownHostsFile ~/.ssh/known_hosts
+          ControlMaster no
+          ControlPath ~/.ssh/master-%r@%n:%p
+          ControlPersist no
+
+        # Local development
+        Host *.local
+          Port ${toString cfg.port}
+
+        # Known hosts
+        ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: host: ''
+          # ${name}
+          Host ${lib.concatStringsSep " " host.hostNames}
+            HostKeyAlias ${name}
+            ${if host ? publicKey then "HostKey ${host.publicKey}" else ""}
+        '') cfg.knownHosts)}
+
+        # User-provided configuration
+        ${cfg.extraConfig}
+      '';
+      
+      # User-defined match blocks
+      matchBlocks = cfg.matchBlocks;
+    };
+
+    # Set up authorized_keys if any keys are provided
+    home.file = lib.mkIf (cfg.authorizedKeys != []) {
+      ".ssh/authorized_keys".text = lib.concatStringsSep "\n" cfg.authorizedKeys;
+    };
+
+    # Shell aliases for SSH key management
+    home.shellAliases = {
+      # Fix SSH permissions
+      ssh-fix-perms = ''
+        find ~/.ssh -type f -not -name "*.pub" -exec chmod 600 {} \; && \
+        find ~/.ssh -type d -exec chmod 700 {} \; && \
+        find ~/.ssh -name "*.pub" -exec chmod 644 {} \;
+      '';
+    };
+  };
+}

--- a/modules/home/applications/terminal/tools/ssh/default.nix
+++ b/modules/home/applications/terminal/tools/ssh/default.nix
@@ -132,10 +132,19 @@ in {
       ];
     };
 
-    # Set up authorized_keys if any keys are provided
-    home.file = lib.mkIf (cfg.authorizedKeys != []) {
-      ".ssh/authorized_keys".text = lib.concatStringsSep "\n" cfg.authorizedKeys;
-    };
+    # Set up SSH related files and directories
+    home.file = lib.mkMerge [
+      # Set up authorized_keys if any keys are provided
+      (lib.optionalAttrs (cfg.authorizedKeys != []) {
+        ".ssh/authorized_keys".text = lib.concatStringsSep "\n" cfg.authorizedKeys;
+      })
+    ];
+    
+    # Create controlmasters directory for connection sharing
+    home.activation.createSshControlmastersDir = lib.hm.dag.entryAfter ["writeBoundary"] ''
+      mkdir -p ~/.ssh/controlmasters
+      chmod 700 ~/.ssh/controlmasters
+    '';
 
     # Shell aliases for SSH key management
     home.shellAliases = {

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -78,6 +78,7 @@
         "modules/home/applications/terminal/tools/bottom/default.nix"
         "modules/home/applications/terminal/tools/btop/default.nix"
         "modules/home/applications/terminal/tools/carapace/default.nix"
+        "modules/home/applications/terminal/tools/ssh/default.nix"
 
         ## Shells
         "modules/home/applications/terminal/shells/zsh/default.nix"

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -40,7 +40,7 @@ in {
   # SSH configuration
   applications.terminal.tools.ssh.knownHosts."github".hostNames = ["github.com"];
   applications.terminal.tools.ssh.knownHosts."github".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
-  
+
   # Sudo configuration
   darwin.security.sudo.enable = true;
 

--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -40,7 +40,7 @@ in {
   # SSH configuration
   applications.terminal.tools.ssh.knownHosts."github".hostNames = ["github.com"];
   applications.terminal.tools.ssh.knownHosts."github".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
-
+  
   # Sudo configuration
   darwin.security.sudo.enable = true;
 


### PR DESCRIPTION
This pull request introduces a new SSH configuration module for the Nix-based system configuration. The changes add support for managing SSH settings, including known hosts, authorized keys, and advanced SSH options, directly through the configuration files. Below is a summary of the most important changes:

### SSH Configuration Module

* Added a new SSH configuration module (`modules/home/applications/terminal/tools/ssh/default.nix`) that includes options for enabling SSH, configuring known hosts, managing authorized keys, and specifying advanced SSH settings such as match blocks and security options.
* Integrated the new SSH module into the system by referencing it in the supported systems file (`supported-systems/aarch64-darwin/src/wang-lin/default.nix`).

### SSH Configuration in User Profile

* Enabled the SSH configuration in the user's profile (`homes/aarch64-darwin/aytordev@wang-lin/default.nix`) with additional options for known hosts and extra configuration overrides.