### PR TITLE
feat(terminal/tools): add comma nix-shell wrapper

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -33,6 +33,7 @@
   applications.terminal.tools.bottom.enable = true;
   applications.terminal.tools.btop.enable = true;
   applications.terminal.tools.carapace.enable = true;
+  applications.terminal.tools.comma.enable = true;
   applications.terminal.tools.ssh.enable = true;
   applications.terminal.tools.ssh.knownHosts = {
     github = {

--- a/modules/home/applications/terminal/tools/comma/default.nix
+++ b/modules/home/applications/terminal/tools/comma/default.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.applications.terminal.tools.comma;
+in {
+  options.applications.terminal.tools.comma = {
+    enable = mkEnableOption "comma";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      comma
+      nix-index
+    ];
+
+    programs = {
+      nix-index = {
+        enable = true;
+        package = pkgs.nix-index;
+        enableBashIntegration = true;
+        enableFishIntegration = true;
+        enableZshIntegration = true;
+      };
+    };
+  };
+}

--- a/modules/home/applications/terminal/tools/ssh/default.nix
+++ b/modules/home/applications/terminal/tools/ssh/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }: let
   inherit (lib) mkEnableOption mkOption types;
@@ -124,12 +125,17 @@ in {
       mkdir -p ~/.ssh/controlmasters
       chmod 700 ~/.ssh/controlmasters
     '';
+    home.packages = [
+      (pkgs.writeShellScriptBin "ssh-fix-perms" ''
+        #!/bin/sh
+        find "$HOME/.ssh" -type f -not -name "*.pub" -exec chmod 600 {} +
+        find "$HOME/.ssh" -type d -exec chmod 700 {} +
+        find "$HOME/.ssh" -name "*.pub" -exec chmod 644 {} + 2>/dev/null
+      '')
+    ];
+    
     home.shellAliases = {
-      ssh-fix-perms = ''
-        find ~/.ssh -type f -not -name "*.pub" -exec chmod 600 {} \; && \
-        find ~/.ssh -type d -exec chmod 700 {} \; && \
-        find ~/.ssh -name "*.pub" -exec chmod 644 {} \;
-      '';
+      ssh-fix-perms = "${config.home.profileDirectory}/bin/ssh-fix-perms";
     };
   };
 }

--- a/modules/home/applications/terminal/tools/ssh/default.nix
+++ b/modules/home/applications/terminal/tools/ssh/default.nix
@@ -133,7 +133,7 @@ in {
         find "$HOME/.ssh" -name "*.pub" -exec chmod 644 {} + 2>/dev/null
       '')
     ];
-    
+
     home.shellAliases = {
       ssh-fix-perms = "${config.home.profileDirectory}/bin/ssh-fix-perms";
     };

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -42,6 +42,7 @@
         "modules/home/applications/terminal/tools/btop/default.nix"
         "modules/home/applications/terminal/tools/carapace/default.nix"
         "modules/home/applications/terminal/tools/ssh/default.nix"
+        "modules/home/applications/terminal/tools/comma/default.nix"
         "modules/home/applications/terminal/shells/zsh/default.nix"
         "modules/home/applications/terminal/shells/bash/default.nix"
         "modules/home/applications/terminal/shells/fish/default.nix"


### PR DESCRIPTION
This pull request introduces the addition of a new terminal tool called `comma`, along with improvements to the SSH configuration. The most notable changes include enabling and configuring `comma` in the terminal tools module, adding a script for fixing SSH permissions, and updating the supported systems file to include the new `comma` tool.

### Additions and Configuration for `comma` Tool:
* Added `comma` to the list of enabled terminal tools in `homes/aarch64-darwin/aytordev@wang-lin/default.nix`.
* Created a new configuration file for `comma` in `modules/home/applications/terminal/tools/comma/default.nix`, which includes options to enable the tool, add it to `home.packages`, and configure `nix-index` with shell integrations for Bash, Fish, and Zsh.
* Updated the supported systems file to include the new `comma` tool in `supported-systems/aarch64-darwin/src/wang-lin/default.nix`.

### Improvements to SSH Configuration:
* Added a `home.packages` entry in `modules/home/applications/terminal/tools/ssh/default.nix` to include a script (`ssh-fix-perms`) for fixing SSH file and directory permissions. This replaces the previous shell alias with a binary script.
* Minor adjustment to import `pkgs` in the SSH configuration file to support the new script.