### PR TITLE
:sparkles: feat(terminal): add direnv support with nix-direnv integration

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -47,4 +47,7 @@
   };
   applications.terminal.tools.ssh.extraConfig = ''
   '';
+  applications.terminal.tools.direnv.enable = true;
+  applications.terminal.tools.direnv.nix-direnv = true;
+  applications.terminal.tools.direnv.silent = true;
 }

--- a/modules/home/applications/terminal/tools/direnv/default.nix
+++ b/modules/home/applications/terminal/tools/direnv/default.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.applications.terminal.tools.direnv;
+in {
+  options.applications.terminal.tools.direnv = {
+    enable = mkEnableOption "direnv - A shell extension that manages your environment";
+
+    nix-direnv = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable nix-direnv for faster and more persistent Nix shell environments";
+    };
+
+    silent = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to silence direnv output by default";
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      home.packages = with pkgs; [
+        direnv
+      ];
+    }
+
+    (mkIf cfg.nix-direnv {
+      home.packages = with pkgs; [
+        nix-direnv
+      ];
+
+      # Ensure nix-direnv is properly set up
+      home.file.".config/nix-direnv/nix-direnv.toml".text = ''
+        [nix]
+        enable = true
+      '';
+    })
+
+    {
+      programs.direnv = {
+        enable = true;
+        nix-direnv.enable = cfg.nix-direnv;
+        silent = cfg.silent;
+
+        # Configure direnv to use the nix-direnv integration if enabled
+        config = mkIf cfg.nix-direnv {
+          whitelist = {
+            prefix = [
+              "${config.home.homeDirectory}/Developer"
+            ];
+          };
+        };
+      };
+    }
+  ]);
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -43,6 +43,7 @@
         "modules/home/applications/terminal/tools/carapace/default.nix"
         "modules/home/applications/terminal/tools/ssh/default.nix"
         "modules/home/applications/terminal/tools/comma/default.nix"
+        "modules/home/applications/terminal/tools/direnv/default.nix"
         "modules/home/applications/terminal/shells/zsh/default.nix"
         "modules/home/applications/terminal/shells/bash/default.nix"
         "modules/home/applications/terminal/shells/fish/default.nix"


### PR DESCRIPTION
This pull request introduces support for configuring `direnv` and its integration with `nix-direnv` in the Nix-based home configuration. The changes include enabling `direnv` by default, adding options for its configuration, and ensuring proper setup for `nix-direnv`.

### Enhancements to `direnv` support:

* **Enabled `direnv` in the home configuration**: Added settings to enable `direnv` and configure its integration with `nix-direnv` and silent mode in the `homes/aarch64-darwin/aytordev@wang-lin/default.nix` file. (`[homes/aarch64-darwin/aytordev@wang-lin/default.nixR50-R52](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bR50-R52)`)
* **Introduced `direnv` module**: Created a new module in `modules/home/applications/terminal/tools/direnv/default.nix` to define options for enabling `direnv`, configuring `nix-direnv`, and setting silent mode. This module also ensures `nix-direnv` is properly set up if enabled. (`[modules/home/applications/terminal/tools/direnv/default.nixR1-R62](diffhunk://#diff-4324d5bcc3152701f9bb174c394d11ad5fc98c32838a7a59ed5228bac7735d85R1-R62)`)

### System configuration updates:

* **Added `direnv` module to supported systems**: Included the new `direnv` module in the list of terminal tools for supported systems in `supported-systems/aarch64-darwin/src/wang-lin/default.nix`. (`[supported-systems/aarch64-darwin/src/wang-lin/default.nixR46](diffhunk://#diff-80fa091607f0022f5215bf9e69c8ac7093fd2b605ccd9364cff9be483b24a3a5R46)`)