### PR TITLE
feat(terminal): add fastfetch module with custom configuration

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -28,6 +28,7 @@
   applications.terminal.tools.atuin.enable = true;
   applications.terminal.tools.atuin.enableBashIntegration = true;
   applications.terminal.tools.atuin.enableFishIntegration = true;
+  applications.terminal.tools.fastfetch.enable = true;
   applications.terminal.tools.atuin.enableZshIntegration = true;
   applications.terminal.tools.atuin.enableNushellIntegration = true;
   applications.terminal.tools.bottom.enable = true;

--- a/modules/home/applications/terminal/tools/fastfetch/default.nix
+++ b/modules/home/applications/terminal/tools/fastfetch/default.nix
@@ -1,0 +1,157 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkEnableOption mkIf;
+
+in {
+  options.applications.terminal.tools.fastfetch = {
+    enable = mkEnableOption "fastfetch";
+  };
+
+  config = mkIf config.applications.terminal.tools.fastfetch.enable {
+    home.packages = with pkgs; [ fastfetchMinimal ];
+
+    programs.fastfetch = {
+      enable = true;
+      package = pkgs.fastfetchMinimal;
+
+      settings = {
+        "$schema" = "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json";
+        logo = {
+          padding = {
+            top = 2;
+          };
+        };
+        display = {
+          color = {
+            keys = "green";
+            title = "blue";
+          };
+          percent = {
+            type = 9;
+          };
+          separator = " 󰁔 ";
+        };
+        modules =
+          [
+            {
+              type = "custom";
+              outputColor = "blue";
+              format = "┌──────────── OS Information ────────────┐";
+            }
+            {
+              type = "title";
+              key = " ╭─ ";
+              keyColor = "green";
+              color = {
+                user = "green";
+                host = "green";
+              };
+            }
+          ]
+          ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+            {
+              type = "os";
+              key = " ├─  ";
+              keyColor = "green";
+            }
+            {
+              type = "kernel";
+              key = " ├─  ";
+              keyColor = "green";
+            }
+            {
+              type = "packages";
+              key = " ├─  ";
+              keyColor = "green";
+            }
+          ]
+          ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+            {
+              type = "os";
+              key = " ├─ ";
+              keyColor = "green";
+            }
+            {
+              type = "kernel";
+              key = " ├─ ";
+              keyColor = "green";
+            }
+            {
+              type = "packages";
+              key = " ├─ ";
+              keyColor = "green";
+            }
+          ]
+          ++ [
+            {
+              type = "shell";
+              key = " ╰─  ";
+              keyColor = "green";
+            }
+            {
+              type = "custom";
+              outputColor = "blue";
+              format = "├───────── Hardware Information ─────────┤";
+            }
+            {
+              type = "display";
+              key = " ╭─ 󰍹 ";
+              keyColor = "blue";
+              compactType = "original-with-refresh-rate";
+            }
+            {
+              type = "cpu";
+              key = " ├─ 󰍛 ";
+              keyColor = "blue";
+            }
+            {
+              type = "gpu";
+              key = " ├─  ";
+              keyColor = "blue";
+            }
+            {
+              type = "disk";
+              key = " ├─ 󱛟 ";
+              keyColor = "blue";
+            }
+            {
+              type = "memory";
+              key = " ╰─  ";
+              keyColor = "blue";
+            }
+            {
+              type = "custom";
+              outputColor = "blue";
+              format = "├───────── Software Information ─────────┤";
+            }
+            {
+              type = "wm";
+              key = " ╭─  ";
+              keyColor = "yellow";
+            }
+            {
+              type = "terminal";
+              key = " ├─  ";
+              keyColor = "yellow";
+            }
+            {
+              type = "font";
+              key = " ╰─  ";
+              keyColor = "yellow";
+            }
+            {
+              type = "custom";
+              outputColor = "blue";
+              format = "└────────────────────────────────────────┘";
+            }
+            {
+              type = "custom";
+              format = "   {#39}   {#34}    {#36}    {#35}    {#34}    {#33}    {#32}    {#31} ";
+            }
+            "break"
+          ];
+      };
+    };
+  };
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -45,6 +45,7 @@
         "modules/home/applications/terminal/tools/comma/default.nix"
         "modules/home/applications/terminal/tools/direnv/default.nix"
         "modules/home/applications/terminal/tools/eza/default.nix"
+        "modules/home/applications/terminal/tools/fastfetch/default.nix"
         "modules/home/applications/terminal/shells/zsh/default.nix"
         "modules/home/applications/terminal/shells/bash/default.nix"
         "modules/home/applications/terminal/shells/fish/default.nix"


### PR DESCRIPTION
This pull request introduces support for the `fastfetch` tool in the configuration, enabling it as a customizable terminal utility. The changes include adding `fastfetch` to the supported tools, defining its configuration options, and integrating it into the system.

### Addition of `fastfetch` Tool:

* **Enabled `fastfetch` in terminal tools configuration**: Added `fastfetch` to the list of terminal tools in the `homes/aarch64-darwin/aytordev@wang-lin/default.nix` file, enabling its use in the terminal.

* **Defined `fastfetch` configuration module**: Introduced a new module in `modules/home/applications/terminal/tools/fastfetch/default.nix` to configure `fastfetch`. This includes enabling the tool, specifying its package, and defining detailed settings such as logo padding, color schemes, and module displays for OS, hardware, and software information.

* **Added `fastfetch` to supported systems**: Included the `fastfetch` configuration module in the list of supported terminal tools for the `aarch64-darwin` system in `supported-systems/aarch64-darwin/src/wang-lin/default.nix`.