### PR TITLE
feat(terminal/tools): add git-crypt module

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -53,4 +53,5 @@
   applications.terminal.tools.direnv.silent = true;
   applications.terminal.tools.eza.enable = true;
   applications.terminal.tools.gh.enable = true;
+  applications.terminal.tools.git-crypt.enable = true;
 }

--- a/modules/home/applications/terminal/tools/git-crypt/default.nix
+++ b/modules/home/applications/terminal/tools/git-crypt/default.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.applications.terminal.tools.git-crypt;
+in {
+  options.applications.terminal.tools.git-crypt = {
+    enable = mkEnableOption "git-crypt - Transparent file encryption in git";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [ git-crypt ];
+  };
+}

--- a/modules/home/applications/terminal/tools/git-crypt/default.nix
+++ b/modules/home/applications/terminal/tools/git-crypt/default.nix
@@ -4,10 +4,7 @@
   pkgs,
   ...
 }:
-
-with lib;
-
-let
+with lib; let
   cfg = config.applications.terminal.tools.git-crypt;
 in {
   options.applications.terminal.tools.git-crypt = {
@@ -15,6 +12,6 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = with pkgs; [ git-crypt ];
+    home.packages = with pkgs; [git-crypt];
   };
 }

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -47,6 +47,7 @@
         "modules/home/applications/terminal/tools/eza/default.nix"
         "modules/home/applications/terminal/tools/fastfetch/default.nix"
         "modules/home/applications/terminal/tools/gh/default.nix"
+        "modules/home/applications/terminal/tools/git-crypt/default.nix"
         "modules/home/applications/terminal/shells/zsh/default.nix"
         "modules/home/applications/terminal/shells/bash/default.nix"
         "modules/home/applications/terminal/shells/fish/default.nix"


### PR DESCRIPTION
This pull request introduces support for the `git-crypt` tool in the terminal applications configuration. The changes include enabling `git-crypt` as an option, adding its module definition, and integrating it into the supported systems.

### Added support for `git-crypt`:

* [`homes/aarch64-darwin/aytordev@wang-lin/default.nix`](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bR56): Enabled the `git-crypt` tool in the terminal applications configuration by setting `applications.terminal.tools.git-crypt.enable` to `true`.
* [`modules/home/applications/terminal/tools/git-crypt/default.nix`](diffhunk://#diff-82230ae74a75047a20b059382e8d3b265c6946cfa3276cd3ae1bfd7c13dc17c0R1-R17): Added a new module definition for `git-crypt`, including an `enable` option and the logic to include `git-crypt` in the `home.packages` list when enabled.
* [`supported-systems/aarch64-darwin/src/wang-lin/default.nix`](diffhunk://#diff-80fa091607f0022f5215bf9e69c8ac7093fd2b605ccd9364cff9be483b24a3a5R50): Registered the `git-crypt` module in the list of supported terminal tools.