### PR TITLE
feat(terminal/tools): add jq module

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -48,6 +48,7 @@
   };
   applications.terminal.tools.ssh.extraConfig = ''
   '';
+  applications.terminal.tools.jq.enable = true;
   applications.terminal.tools.direnv.enable = true;
   applications.terminal.tools.direnv.nix-direnv = true;
   applications.terminal.tools.direnv.silent = true;

--- a/modules/home/applications/terminal/tools/git/default.nix
+++ b/modules/home/applications/terminal/tools/git/default.nix
@@ -12,7 +12,6 @@
   shell-aliases = import ./shell-aliases.nix {inherit config lib pkgs;};
   gitPackages = with pkgs; [
     git-absorb
-    git-crypt
     git-filter-repo
     git-lfs
     gitflow

--- a/modules/home/applications/terminal/tools/jq/default.nix
+++ b/modules/home/applications/terminal/tools/jq/default.nix
@@ -4,10 +4,7 @@
   pkgs,
   ...
 }:
-
-with lib;
-
-let
+with lib; let
   cfg = config.applications.terminal.tools.jq;
 in {
   options.applications.terminal.tools.jq = {

--- a/modules/home/applications/terminal/tools/jq/default.nix
+++ b/modules/home/applications/terminal/tools/jq/default.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.applications.terminal.tools.jq;
+in {
+  options.applications.terminal.tools.jq = {
+    enable = mkEnableOption "jq";
+  };
+
+  config = mkIf cfg.enable {
+    programs.jq = {
+      enable = true;
+      package = pkgs.jq;
+    };
+  };
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -48,6 +48,7 @@
         "modules/home/applications/terminal/tools/fastfetch/default.nix"
         "modules/home/applications/terminal/tools/gh/default.nix"
         "modules/home/applications/terminal/tools/git-crypt/default.nix"
+        "modules/home/applications/terminal/tools/jq/default.nix"
         "modules/home/applications/terminal/shells/zsh/default.nix"
         "modules/home/applications/terminal/shells/bash/default.nix"
         "modules/home/applications/terminal/shells/fish/default.nix"


### PR DESCRIPTION
This pull request introduces support for enabling and configuring the `jq` tool in the terminal applications setup, removes `git-crypt` from the list of Git-related packages, and updates relevant configuration files to reflect these changes. Below are the most important changes grouped by theme:

### Addition of `jq` Support:
* Added a configuration option to enable `jq` in the terminal tools setup (`applications.terminal.tools.jq.enable`) in `homes/aarch64-darwin/aytordev@wang-lin/default.nix`.
* Introduced a new module for `jq` configuration, allowing it to be enabled and specifying its package (`pkgs.jq`) in `modules/home/applications/terminal/tools/jq/default.nix`.
* Registered the new `jq` module in the list of supported terminal tools in `supported-systems/aarch64-darwin/src/wang-lin/default.nix`.

### Removal of `git-crypt`:
* Removed `git-crypt` from the list of Git-related packages in `modules/home/applications/terminal/tools/git/default.nix`.