### PR TITLE
feat(terminal/tools): add lazygit module

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -57,4 +57,5 @@
   applications.terminal.tools.git-crypt.enable = true;
   applications.terminal.tools.jujutsu.enable = true;
   applications.terminal.tools.jujutsu.signByDefault = true;
+  applications.terminal.tools.lazygit.enable = true;
 }

--- a/modules/home/applications/terminal/tools/lazygit/default.nix
+++ b/modules/home/applications/terminal/tools/lazygit/default.nix
@@ -4,22 +4,19 @@
   inputs,
   pkgs,
   ...
-}:
-
-{
+}: {
   options.applications.terminal.tools.lazygit = {
     enable = lib.mkEnableOption "lazygit";
   };
 
   config = lib.mkIf config.applications.terminal.tools.lazygit.enable {
-
     home.packages = with pkgs; [
       lazygit
     ];
 
     programs.lazygit = {
       enable = true;
-      
+
       settings = {
         gui = {
           authorColors = {

--- a/modules/home/applications/terminal/tools/lazygit/default.nix
+++ b/modules/home/applications/terminal/tools/lazygit/default.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  lib,
+  inputs,
+  pkgs,
+  ...
+}:
+
+{
+  options.applications.terminal.tools.lazygit = {
+    enable = lib.mkEnableOption "lazygit";
+  };
+
+  config = lib.mkIf config.applications.terminal.tools.lazygit.enable {
+
+    home.packages = with pkgs; [
+      lazygit
+    ];
+
+    applications.terminal.tools.lazygit = {
+      enable = true;
+      
+      settings = {
+        gui = {
+          authorColors = {
+            "${inputs.secrets.userfullname}" = "#c6a0f6";
+            "dependabot[bot]" = "#eed49f";
+          };
+          branchColors = {
+            main = "#ed8796";
+            master = "#ed8796";
+            dev = "#8bd5ca";
+          };
+          nerdFontsVersion = "3";
+        };
+        git = {
+          overrideGpg = true;
+        };
+      };
+    };
+
+    home.shellAliases = {
+      lg = "lazygit";
+    };
+
+    home.file.".config/bash/conf.d/lazygit.sh" = {
+      text = ''
+        if command -v lazygit &> /dev/null; then
+          alias lg='lazygit'
+        fi
+      '';
+      executable = true;
+    };
+  };
+}

--- a/modules/home/applications/terminal/tools/lazygit/default.nix
+++ b/modules/home/applications/terminal/tools/lazygit/default.nix
@@ -17,7 +17,7 @@
       lazygit
     ];
 
-    applications.terminal.tools.lazygit = {
+    programs.lazygit = {
       enable = true;
       
       settings = {

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -50,6 +50,7 @@
         "modules/home/applications/terminal/tools/git-crypt/default.nix"
         "modules/home/applications/terminal/tools/jq/default.nix"
         "modules/home/applications/terminal/tools/jujutsu/default.nix"
+        "modules/home/applications/terminal/tools/lazygit/default.nix"
         "modules/home/applications/terminal/shells/zsh/default.nix"
         "modules/home/applications/terminal/shells/bash/default.nix"
         "modules/home/applications/terminal/shells/fish/default.nix"


### PR DESCRIPTION
This pull request introduces support for configuring and enabling `lazygit` as a terminal tool in the Nix-based system configuration. The changes include adding a new module for `lazygit`, updating the system configuration to reference it, and enabling `lazygit` in a specific user configuration.

### Addition of `lazygit` Configuration

* **New module for `lazygit`:** Added a module (`modules/home/applications/terminal/tools/lazygit/default.nix`) to configure `lazygit`, including settings for GUI customization, GPG overrides, shell aliases, and a bash configuration script.

### System Configuration Updates

* **System-level inclusion:** Updated the system configuration file (`supported-systems/aarch64-darwin/src/wang-lin/default.nix`) to include the new `lazygit` module.

### User Configuration Updates

* **Enable `lazygit` for a user:** Enabled `lazygit` in the user-specific configuration file (`homes/aarch64-darwin/aytordev@wang-lin/default.nix`).