### PR TITLE
feat(terminal/tools): add navi module

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -36,18 +36,13 @@
   applications.terminal.tools.carapace.enable = true;
   applications.terminal.tools.comma.enable = true;
   applications.terminal.tools.ssh.enable = true;
-  applications.terminal.tools.ssh.knownHosts = {
-    github = {
-      hostNames = ["github.com"];
-      user = "git";
-      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
-      identityFile = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
-      identitiesOnly = true;
-      port = 22;
-    };
-  };
-  applications.terminal.tools.ssh.extraConfig = ''
-  '';
+  applications.terminal.tools.ssh.knownHosts.github.hostNames = ["github.com"];
+  applications.terminal.tools.ssh.knownHosts.github.user = "git";
+  applications.terminal.tools.ssh.knownHosts.github.publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
+  applications.terminal.tools.ssh.knownHosts.github.identityFile = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
+  applications.terminal.tools.ssh.knownHosts.github.identitiesOnly = true;
+  applications.terminal.tools.ssh.knownHosts.github.port = 22;
+  applications.terminal.tools.ssh.extraConfig = '''';
   applications.terminal.tools.jq.enable = true;
   applications.terminal.tools.direnv.enable = true;
   applications.terminal.tools.direnv.nix-direnv = true;
@@ -59,4 +54,14 @@
   applications.terminal.tools.jujutsu.signByDefault = true;
   applications.terminal.tools.lazygit.enable = true;
   applications.terminal.tools.lazydocker.enable = true;
+  applications.terminal.tools.navi.enable = true;
+  applications.terminal.tools.navi.settings.style.tag.color = "green";
+  applications.terminal.tools.navi.settings.style.tag.width_percentage = 26;
+  applications.terminal.tools.navi.settings.style.tag.min_width = 20;
+  applications.terminal.tools.navi.settings.style.comment.color = "blue";
+  applications.terminal.tools.navi.settings.style.comment.width_percentage = 42;
+  applications.terminal.tools.navi.settings.style.comment.min_width = 45;
+  applications.terminal.tools.navi.settings.style.snippet.color = "white";
+  applications.terminal.tools.navi.settings.style.snippet.width_percentage = 42;
+  applications.terminal.tools.navi.settings.style.snippet.min_width = 45;
 }

--- a/modules/home/applications/terminal/tools/navi/default.nix
+++ b/modules/home/applications/terminal/tools/navi/default.nix
@@ -18,8 +18,7 @@
       color = "white";
     };
   };
-in
-{
+in {
   options.applications.terminal.tools.navi = {
     enable = lib.mkEnableOption "navi";
     settings = {

--- a/modules/home/applications/terminal/tools/navi/default.nix
+++ b/modules/home/applications/terminal/tools/navi/default.nix
@@ -1,0 +1,88 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.applications.terminal.tools.navi;
+  inherit (lib) mkIf;
+
+  # Default configuration values
+  defaultStyle = {
+    tag = {
+      color = "green";
+    };
+    comment = {
+      color = "blue";
+    };
+    snippet = {
+      color = "white";
+    };
+  };
+in
+{
+  options.applications.terminal.tools.navi = {
+    enable = lib.mkEnableOption "navi";
+    settings = {
+      style = {
+        tag = {
+          color = lib.mkOption {
+            type = lib.types.str;
+            default = defaultStyle.tag.color;
+            description = "Color for tag text in navi";
+          };
+          width_percentage = lib.mkOption {
+            type = lib.types.int;
+            default = 26;
+            description = "Column width relative to terminal window";
+          };
+          min_width = lib.mkOption {
+            type = lib.types.int;
+            default = 20;
+            description = "Minimum column width as number of characters";
+          };
+        };
+        comment = {
+          color = lib.mkOption {
+            type = lib.types.str;
+            default = defaultStyle.comment.color;
+            description = "Color for comment text in navi";
+          };
+          width_percentage = lib.mkOption {
+            type = lib.types.int;
+            default = 42;
+            description = "Column width relative to terminal window";
+          };
+          min_width = lib.mkOption {
+            type = lib.types.int;
+            default = 45;
+            description = "Minimum column width as number of characters";
+          };
+        };
+        snippet = {
+          color = lib.mkOption {
+            type = lib.types.str;
+            default = defaultStyle.snippet.color;
+            description = "Color for snippet text in navi";
+          };
+          width_percentage = lib.mkOption {
+            type = lib.types.int;
+            default = 42;
+            description = "Column width relative to terminal window";
+          };
+          min_width = lib.mkOption {
+            type = lib.types.int;
+            default = 45;
+            description = "Minimum column width as number of characters";
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.navi = {
+      enable = true;
+      settings = cfg.settings;
+    };
+  };
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -49,6 +49,7 @@
         "modules/home/applications/terminal/tools/gh/default.nix"
         "modules/home/applications/terminal/tools/git-crypt/default.nix"
         "modules/home/applications/terminal/tools/jq/default.nix"
+        "modules/home/applications/terminal/tools/navi/default.nix"
         "modules/home/applications/terminal/tools/jujutsu/default.nix"
         "modules/home/applications/terminal/tools/lazygit/default.nix"
         "modules/home/applications/terminal/tools/lazydocker/default.nix"


### PR DESCRIPTION
This pull request introduces updates to the Nix configuration files, including improvements to the SSH configuration structure, the addition of `navi` terminal tool support, and the integration of its customizable settings. Below is a breakdown of the most significant changes:

### SSH Configuration Improvements:
* Refactored the structure for `applications.terminal.tools.ssh.knownHosts` to use a more concise and hierarchical format for defining the GitHub SSH host configuration. This change simplifies readability and maintainability. (`homes/aarch64-darwin/aytordev@wang-lin/default.nix`, [homes/aarch64-darwin/aytordev@wang-lin/default.nixL39-R45](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bL39-R45))

### Addition of `navi` Terminal Tool:
* Enabled the `navi` terminal tool and added support for detailed customization of its style settings, including color, width percentage, and minimum width for tags, comments, and snippets. (`homes/aarch64-darwin/aytordev@wang-lin/default.nix`, [homes/aarch64-darwin/aytordev@wang-lin/default.nixR57-R66](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bR57-R66))
* Introduced a new module for `navi` (`modules/home/applications/terminal/tools/navi/default.nix`) that defines its configuration options, default values, and integration with the system. (`modules/home/applications/terminal/tools/navi/default.nix`, [modules/home/applications/terminal/tools/navi/default.nixR1-R87](diffhunk://#diff-9d9d319fa492c363e9aa43e8b7b8a879eb1172cc4885b9ff402af358fd9411d4R1-R87))
* Registered the `navi` module in the supported systems configuration to ensure it is included in the build. (`supported-systems/aarch64-darwin/src/wang-lin/default.nix`, [supported-systems/aarch64-darwin/src/wang-lin/default.nixR52](diffhunk://#diff-80fa091607f0022f5215bf9e69c8ac7093fd2b605ccd9364cff9be483b24a3a5R52))