### PR TITLE
feat(terminal/tools): add nh module

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -48,6 +48,7 @@
   applications.terminal.tools.direnv.nix-direnv = true;
   applications.terminal.tools.direnv.silent = true;
   applications.terminal.tools.eza.enable = true;
+  applications.terminal.tools.nh.enable = true;
   applications.terminal.tools.gh.enable = true;
   applications.terminal.tools.git-crypt.enable = true;
   applications.terminal.tools.jujutsu.enable = true;

--- a/modules/home/applications/terminal/tools/nh/default.nix
+++ b/modules/home/applications/terminal/tools/nh/default.nix
@@ -24,8 +24,11 @@
   };
 
   # Platform-specific nixre alias
-  nixreAlias = "nh ${if pkgs.stdenv.hostPlatform.isLinux then "os" else "darwin"} switch";
-
+  nixreAlias = "nh ${
+    if pkgs.stdenv.hostPlatform.isLinux
+    then "os"
+    else "darwin"
+  } switch";
 in {
   options.applications.terminal.tools.nh = {
     enable = lib.mkEnableOption "nh";

--- a/modules/home/applications/terminal/tools/nh/default.nix
+++ b/modules/home/applications/terminal/tools/nh/default.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}: let
+  cfg = config.applications.terminal.tools.nh;
+  inherit (lib) mkIf;
+
+  # Default configuration values
+  defaultConfig = {
+    clean.enable = true;
+    flake = "/Users/${inputs.secrets.username}";
+  };
+
+  nhPackage = pkgs.nh.overrideAttrs {
+    patches = [
+      (pkgs.fetchpatch {
+        url = "https://github.com/nix-community/nh/pull/340.patch";
+        hash = "sha256-AYrogYKEbwCO4MWoiGIt9I5gDv8XiPEA7DiPaYtNnD8=";
+      })
+    ];
+  };
+
+  # Platform-specific nixre alias
+  nixreAlias = "nh ${if pkgs.stdenv.hostPlatform.isLinux then "os" else "darwin"} switch";
+
+in {
+  options.applications.terminal.tools.nh = {
+    enable = lib.mkEnableOption "nh";
+    clean = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = defaultConfig.clean.enable;
+        description = "Enable nh clean functionality";
+      };
+    };
+    flake = lib.mkOption {
+      type = lib.types.str;
+      default = defaultConfig.flake;
+      description = "Path to the flake to use with nh";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.nh = {
+      enable = true;
+      package = nhPackage;
+      clean.enable = cfg.clean.enable;
+      flake = cfg.flake;
+    };
+
+    home = {
+      sessionVariables = {
+        NH_SEARCH_PLATFORM = 1;
+      };
+      shellAliases.nixre = nixreAlias;
+    };
+  };
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -48,6 +48,7 @@
         "modules/home/applications/terminal/tools/fastfetch/default.nix"
         "modules/home/applications/terminal/tools/gh/default.nix"
         "modules/home/applications/terminal/tools/git-crypt/default.nix"
+        "modules/home/applications/terminal/tools/nh/default.nix"
         "modules/home/applications/terminal/tools/jq/default.nix"
         "modules/home/applications/terminal/tools/navi/default.nix"
         "modules/home/applications/terminal/tools/jujutsu/default.nix"


### PR DESCRIPTION
This pull request introduces support for the `nh` tool in the terminal applications configuration. The changes include enabling `nh` in the configuration, adding its module with default options and platform-specific settings, and registering the module in the system.

### Addition of `nh` Tool:

* **Enabled `nh` in the terminal tools configuration**: Added the `nh` tool to the list of enabled terminal applications in `homes/aarch64-darwin/aytordev@wang-lin/default.nix`.
* **Created `nh` module**: Added a new module for `nh` in `modules/home/applications/terminal/tools/nh/default.nix`. This module includes:
  - Default configuration values for `clean.enable` and `flake`.
  - A patched `nh` package with a specific GitHub pull request applied.
  - Platform-specific alias for `nixre`.
  - Options for enabling `nh`, configuring cleaning functionality, and specifying the flake path.
  - Integration with the home environment, including session variables and shell aliases.
* **Registered `nh` module**: Included the `nh` module in the system's supported modules list in `supported-systems/aarch64-darwin/src/wang-lin/default.nix`.