### PR TITLE
feat(terminal/tools): add zellij terminal module

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -67,4 +67,5 @@
   applications.terminal.tools.navi.settings.style.snippet.min_width = 45;
   applications.terminal.tools.ripgrep.enable = true;
   applications.terminal.tools.yazi.enable = true;
+  applications.terminal.tools.zellij.enable = true;
 }

--- a/modules/home/applications/terminal/tools/zellij/default.nix
+++ b/modules/home/applications/terminal/tools/zellij/default.nix
@@ -1,0 +1,79 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkIf;
+
+  cfg = config.applications.terminal.tools.zellij;
+
+  zns = "zellij -s $(basename $(pwd)) options --default-cwd $(pwd)";
+  zas = "zellij a $(basename $(pwd))";
+  zo = ''
+    session_name=$(basename "$(pwd)")
+    zellij attach --create "$session_name" options --default-cwd "$(pwd)"
+  '';
+in
+{
+  imports = [
+    ./keybinds.nix
+    ./layouts/dev.nix
+    ./layouts/system.nix
+  ];
+
+  options.applications.terminal.tools.zellij = {
+    enable = lib.mkEnableOption "zellij";
+  };
+
+  config = mkIf cfg.enable {
+    programs = {
+      bash.shellAliases = {
+        inherit zns zas zo;
+      };
+
+      zsh.shellAliases = {
+        inherit zns zas zo;
+      };
+
+      zellij = {
+        enable = true;
+        settings = {
+          # clipboard provider
+          copy_command =
+            if pkgs.stdenv.hostPlatform.isDarwin then
+              "pbcopy"
+            else
+              "";
+
+          auto_layouts = true;
+          default_layout = "dev";
+          default_mode = "locked";
+          support_kitty_keyboard_protocol = true;
+
+          on_force_close = "quit";
+          pane_frames = true;
+          pane_viewport_serialization = true;
+          scrollback_lines_to_serialize = 1000;
+          session_serialization = true;
+
+          ui.pane_frames = {
+            rounded_corners = true;
+            hide_session_name = true;
+          };
+
+          plugins = {
+            tab-bar.path = "tab-bar";
+            status-bar.path = "status-bar";
+            strider.path = "strider";
+            compact-bar.path = "compact-bar";
+          };
+
+          theme = "catppuccin-macchiato";
+        };
+      };
+    };
+  };
+}

--- a/modules/home/applications/terminal/tools/zellij/default.nix
+++ b/modules/home/applications/terminal/tools/zellij/default.nix
@@ -3,9 +3,7 @@
   lib,
   pkgs,
   ...
-}:
-
-let
+}: let
   inherit (lib) mkIf;
 
   cfg = config.applications.terminal.tools.zellij;
@@ -16,8 +14,7 @@ let
     session_name=$(basename "$(pwd)")
     zellij attach --create "$session_name" options --default-cwd "$(pwd)"
   '';
-in
-{
+in {
   imports = [
     ./keybinds.nix
     ./layouts/dev.nix
@@ -43,10 +40,9 @@ in
         settings = {
           # clipboard provider
           copy_command =
-            if pkgs.stdenv.hostPlatform.isDarwin then
-              "pbcopy"
-            else
-              "";
+            if pkgs.stdenv.hostPlatform.isDarwin
+            then "pbcopy"
+            else "";
 
           auto_layouts = true;
           default_layout = "dev";

--- a/modules/home/applications/terminal/tools/zellij/keybinds.nix
+++ b/modules/home/applications/terminal/tools/zellij/keybinds.nix
@@ -13,86 +13,86 @@
                 # Pane Navigation using Alt + hjkl
                 {
                   bind = {
-                    _args = [ "Alt h" ];
-                    _children = [ { MoveFocus._args = [ "Left" ]; } ];
+                    _args = ["Alt h"];
+                    _children = [{MoveFocus._args = ["Left"];}];
                   };
                 }
                 {
                   bind = {
-                    _args = [ "Alt j" ];
-                    _children = [ { MoveFocus._args = [ "Down" ]; } ];
+                    _args = ["Alt j"];
+                    _children = [{MoveFocus._args = ["Down"];}];
                   };
                 }
                 {
                   bind = {
-                    _args = [ "Alt k" ];
-                    _children = [ { MoveFocus._args = [ "Up" ]; } ];
+                    _args = ["Alt k"];
+                    _children = [{MoveFocus._args = ["Up"];}];
                   };
                 }
                 {
                   bind = {
-                    _args = [ "Alt l" ];
-                    _children = [ { MoveFocus._args = [ "Right" ]; } ];
+                    _args = ["Alt l"];
+                    _children = [{MoveFocus._args = ["Right"];}];
                   };
                 }
 
                 # Pane Management (like :split and :vsplit)
                 {
                   bind = {
-                    _args = [ "Alt n" ];
-                    _children = [ { NewPane = { }; } ];
+                    _args = ["Alt n"];
+                    _children = [{NewPane = {};}];
                   };
                 } # New pane below (horizontal split)
                 {
                   bind = {
-                    _args = [ "Alt v" ];
-                    _children = [ { NewPane._props.direction = "Right"; } ];
+                    _args = ["Alt v"];
+                    _children = [{NewPane._props.direction = "Right";}];
                   };
                 } # New pane to the right (vertical split)
                 {
                   bind = {
-                    _args = [ "Alt x" ];
-                    _children = [ { CloseFocus = { }; } ];
+                    _args = ["Alt x"];
+                    _children = [{CloseFocus = {};}];
                   };
                 } # Close focused pane
                 {
                   bind = {
-                    _args = [ "Alt z" ];
-                    _children = [ { ToggleFocusFullscreen = { }; } ];
+                    _args = ["Alt z"];
+                    _children = [{ToggleFocusFullscreen = {};}];
                   };
                 } # Zoom/unzoom pane
 
                 # Tab Management
                 {
                   bind = {
-                    _args = [ "Alt t" ];
-                    _children = [ { NewTab = { }; } ];
+                    _args = ["Alt t"];
+                    _children = [{NewTab = {};}];
                   };
                 } # New tab
                 {
                   bind = {
-                    _args = [ "Ctrl l" ];
-                    _children = [ { GoToNextTab = { }; } ];
+                    _args = ["Ctrl l"];
+                    _children = [{GoToNextTab = {};}];
                   };
                 } # Go to next tab
                 {
                   bind = {
-                    _args = [ "Ctrl h" ];
-                    _children = [ { GoToPreviousTab = { }; } ];
+                    _args = ["Ctrl h"];
+                    _children = [{GoToPreviousTab = {};}];
                   };
                 } # Go to previous tab
 
                 # Enter other modes
                 {
                   bind = {
-                    _args = [ "Alt s" ];
-                    _children = [ { SwitchToMode._args = [ "Scroll" ]; } ];
+                    _args = ["Alt s"];
+                    _children = [{SwitchToMode._args = ["Scroll"];}];
                   };
                 }
                 {
                   bind = {
-                    _args = [ "Alt r" ];
-                    _children = [ { SwitchToMode._args = [ "RenamePane" ]; } ];
+                    _args = ["Alt r"];
+                    _children = [{SwitchToMode._args = ["RenamePane"];}];
                   };
                 }
               ];
@@ -107,7 +107,7 @@
                       "j"
                       "Down"
                     ];
-                    _children = [ { ScrollDown = { }; } ];
+                    _children = [{ScrollDown = {};}];
                   };
                 }
                 {
@@ -116,7 +116,7 @@
                       "k"
                       "Up"
                     ];
-                    _children = [ { ScrollUp = { }; } ];
+                    _children = [{ScrollUp = {};}];
                   };
                 }
                 {
@@ -125,7 +125,7 @@
                       "q"
                       "Esc"
                     ];
-                    _children = [ { SwitchToMode._args = [ "Locked" ]; } ];
+                    _children = [{SwitchToMode._args = ["Locked"];}];
                   };
                 }
               ];
@@ -136,17 +136,17 @@
               _children = [
                 {
                   bind = {
-                    _args = [ "Enter" ];
-                    _children = [ { SwitchToMode._args = [ "Locked" ]; } ];
+                    _args = ["Enter"];
+                    _children = [{SwitchToMode._args = ["Locked"];}];
                   };
                 }
                 {
                   bind = {
-                    _args = [ "Esc" ];
+                    _args = ["Esc"];
                     # This demonstrates multiple actions for a single bind
                     _children = [
-                      { UndoRenamePane = { }; }
-                      { SwitchToMode._args = [ "Locked" ]; }
+                      {UndoRenamePane = {};}
+                      {SwitchToMode._args = ["Locked"];}
                     ];
                   };
                 }

--- a/modules/home/applications/terminal/tools/zellij/keybinds.nix
+++ b/modules/home/applications/terminal/tools/zellij/keybinds.nix
@@ -1,0 +1,160 @@
+{
+  config = {
+    programs = {
+      zellij = {
+        settings = {
+          keybinds = {
+            # This clears all default keybindings to start fresh.
+            # _props.clear-defaults = true;
+
+            # Keybindings for the "locked" mode (Vim's normal mode equivalent)
+            locked = {
+              _children = [
+                # Pane Navigation using Alt + hjkl
+                {
+                  bind = {
+                    _args = [ "Alt h" ];
+                    _children = [ { MoveFocus._args = [ "Left" ]; } ];
+                  };
+                }
+                {
+                  bind = {
+                    _args = [ "Alt j" ];
+                    _children = [ { MoveFocus._args = [ "Down" ]; } ];
+                  };
+                }
+                {
+                  bind = {
+                    _args = [ "Alt k" ];
+                    _children = [ { MoveFocus._args = [ "Up" ]; } ];
+                  };
+                }
+                {
+                  bind = {
+                    _args = [ "Alt l" ];
+                    _children = [ { MoveFocus._args = [ "Right" ]; } ];
+                  };
+                }
+
+                # Pane Management (like :split and :vsplit)
+                {
+                  bind = {
+                    _args = [ "Alt n" ];
+                    _children = [ { NewPane = { }; } ];
+                  };
+                } # New pane below (horizontal split)
+                {
+                  bind = {
+                    _args = [ "Alt v" ];
+                    _children = [ { NewPane._props.direction = "Right"; } ];
+                  };
+                } # New pane to the right (vertical split)
+                {
+                  bind = {
+                    _args = [ "Alt x" ];
+                    _children = [ { CloseFocus = { }; } ];
+                  };
+                } # Close focused pane
+                {
+                  bind = {
+                    _args = [ "Alt z" ];
+                    _children = [ { ToggleFocusFullscreen = { }; } ];
+                  };
+                } # Zoom/unzoom pane
+
+                # Tab Management
+                {
+                  bind = {
+                    _args = [ "Alt t" ];
+                    _children = [ { NewTab = { }; } ];
+                  };
+                } # New tab
+                {
+                  bind = {
+                    _args = [ "Ctrl l" ];
+                    _children = [ { GoToNextTab = { }; } ];
+                  };
+                } # Go to next tab
+                {
+                  bind = {
+                    _args = [ "Ctrl h" ];
+                    _children = [ { GoToPreviousTab = { }; } ];
+                  };
+                } # Go to previous tab
+
+                # Enter other modes
+                {
+                  bind = {
+                    _args = [ "Alt s" ];
+                    _children = [ { SwitchToMode._args = [ "Scroll" ]; } ];
+                  };
+                }
+                {
+                  bind = {
+                    _args = [ "Alt r" ];
+                    _children = [ { SwitchToMode._args = [ "RenamePane" ]; } ];
+                  };
+                }
+              ];
+            };
+
+            # Keybindings for "scroll" mode (for scrolling up/down the buffer)
+            scroll = {
+              _children = [
+                {
+                  bind = {
+                    _args = [
+                      "j"
+                      "Down"
+                    ];
+                    _children = [ { ScrollDown = { }; } ];
+                  };
+                }
+                {
+                  bind = {
+                    _args = [
+                      "k"
+                      "Up"
+                    ];
+                    _children = [ { ScrollUp = { }; } ];
+                  };
+                }
+                {
+                  bind = {
+                    _args = [
+                      "q"
+                      "Esc"
+                    ];
+                    _children = [ { SwitchToMode._args = [ "Locked" ]; } ];
+                  };
+                }
+              ];
+            };
+
+            # Keybindings for renaming a pane
+            renamepane = {
+              _children = [
+                {
+                  bind = {
+                    _args = [ "Enter" ];
+                    _children = [ { SwitchToMode._args = [ "Locked" ]; } ];
+                  };
+                }
+                {
+                  bind = {
+                    _args = [ "Esc" ];
+                    # This demonstrates multiple actions for a single bind
+                    _children = [
+                      { UndoRenamePane = { }; }
+                      { SwitchToMode._args = [ "Locked" ]; }
+                    ];
+                  };
+                }
+              ];
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/home/applications/terminal/tools/zellij/layouts/dev.nix
+++ b/modules/home/applications/terminal/tools/zellij/layouts/dev.nix
@@ -1,0 +1,98 @@
+{
+  config = {
+    programs = {
+      zellij = {
+        layouts = {
+          dev = {
+            layout = {
+              _children = [
+                {
+                  default_tab_template = {
+                    _children = [
+                      {
+                        pane = {
+                          size = 1;
+                          borderless = true;
+                          plugin = {
+                            location = "zellij:tab-bar";
+                          };
+                        };
+                      }
+                      { "children" = { }; }
+                      {
+                        pane = {
+                          size = 2;
+                          borderless = true;
+                          plugin = {
+                            location = "zellij:status-bar";
+                          };
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Project";
+                      focus = true;
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "nvim";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Git";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "lazygit";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Files";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "yazi";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Shell";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "zsh";
+                        };
+                      }
+                    ];
+                  };
+                }
+              ];
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/home/applications/terminal/tools/zellij/layouts/dev.nix
+++ b/modules/home/applications/terminal/tools/zellij/layouts/dev.nix
@@ -18,7 +18,7 @@
                           };
                         };
                       }
-                      { "children" = { }; }
+                      {"children" = {};}
                       {
                         pane = {
                           size = 2;

--- a/modules/home/applications/terminal/tools/zellij/layouts/system.nix
+++ b/modules/home/applications/terminal/tools/zellij/layouts/system.nix
@@ -18,7 +18,7 @@
                           };
                         };
                       }
-                      { "children" = { }; }
+                      {"children" = {};}
                       {
                         pane = {
                           size = 2;
@@ -64,7 +64,7 @@
                           ];
                         };
                       }
-                      { "children" = { }; }
+                      {"children" = {};}
                       {
                         pane = {
                           size = 2;
@@ -87,7 +87,7 @@
                         pane = {
                           split_direction = "horizontal";
                           _children = [
-                            { "children" = { }; }
+                            {"children" = {};}
                             {
                               pane = {
                                 command = "zsh";

--- a/modules/home/applications/terminal/tools/zellij/layouts/system.nix
+++ b/modules/home/applications/terminal/tools/zellij/layouts/system.nix
@@ -1,0 +1,235 @@
+{
+  config = {
+    programs = {
+      zellij = {
+        layouts = {
+          system = {
+            layout = {
+              _children = [
+                {
+                  default_tab_template = {
+                    _children = [
+                      {
+                        pane = {
+                          size = 1;
+                          borderless = true;
+                          plugin = {
+                            location = "zellij:tab-bar";
+                          };
+                        };
+                      }
+                      { "children" = { }; }
+                      {
+                        pane = {
+                          size = 2;
+                          borderless = true;
+                          plugin = {
+                            location = "zellij:status-bar";
+                          };
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab_template = {
+                    _props = {
+                      name = "dev_tab";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          size = 1;
+                          borderless = true;
+                          plugin = {
+                            location = "zellij:tab-bar";
+                          };
+                        };
+                      }
+                      {
+                        pane = {
+                          split_direction = "Vertical";
+                          _children = [
+                            {
+                              pane = {
+                                size = "15%";
+                                _props = {
+                                  name = "Filetree";
+                                };
+                                plugin = {
+                                  location = "zellij:strider";
+                                };
+                              };
+                            }
+                          ];
+                        };
+                      }
+                      { "children" = { }; }
+                      {
+                        pane = {
+                          size = 2;
+                          borderless = true;
+                          plugin = {
+                            location = "zellij:status-bar";
+                          };
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  pane_template = {
+                    _props = {
+                      name = "term";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          split_direction = "horizontal";
+                          _children = [
+                            { "children" = { }; }
+                            {
+                              pane = {
+                                command = "zsh";
+                                size = "25%";
+                                _props = {
+                                  name = "Shell";
+                                };
+                              };
+                            }
+                          ];
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "khanelinix";
+                      focus = true;
+                      cwd = "$HOME/khanelinix/";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "nvim";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Git";
+                      split_direction = "horizontal";
+                      cwd = "$HOME/khanelinix/";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "lazygit";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Files";
+                      split_direction = "horizontal";
+                      cwd = "$HOME";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "yazi";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Shell";
+                      split_direction = "horizontal";
+                      cwd = "$HOME/khanelinix/";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "zsh";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Processes";
+                      split_direction = "vertical";
+                      cwd = "$HOME";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "btop";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Media";
+                      split_direction = "vertical";
+                      cwd = "$HOME/Music";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          split_direction = "horizontal";
+                          _props = {
+                            name = "Player";
+                          };
+                          _children = [
+                            {
+                              pane = {
+                                command = "musikcube";
+                              };
+                            }
+                          ];
+                        };
+                      }
+                      {
+                        pane = {
+                          split_direction = "horizontal";
+                          _props = {
+                            name = "Mixer";
+                          };
+                          _children = [
+                            {
+                              pane = {
+                                size = "35%";
+                                command = "pulsemixer";
+                              };
+                            }
+                          ];
+                        };
+                      }
+                    ];
+                  };
+                }
+              ];
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -55,6 +55,7 @@
         "modules/home/applications/terminal/tools/lazygit/default.nix"
         "modules/home/applications/terminal/tools/lazydocker/default.nix"
         "modules/home/applications/terminal/tools/ripgrep/default.nix"
+        "modules/home/applications/terminal/tools/zellij/default.nix"
         "modules/home/applications/terminal/tools/yazi/default.nix"
         "modules/home/applications/terminal/shells/zsh/default.nix"
         "modules/home/applications/terminal/shells/bash/default.nix"


### PR DESCRIPTION
This pull request introduces support for the terminal multiplexer `zellij` by adding its configuration, keybinds, layouts, and enabling its integration into the system. The most important changes include enabling `zellij` in the terminal tools configuration, defining its settings and shell aliases, adding custom keybindings, and creating two distinct layouts (`dev` and `system`) for different use cases.

### Addition of `zellij` Support:

* **Enabling `zellij` in terminal tools**:
  - Added `zellij` to the terminal tools configuration, enabling it by default. (`homes/aarch64-darwin/aytordev@wang-lin/default.nix`, [homes/aarch64-darwin/aytordev@wang-lin/default.nixR70](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bR70))
  - Included the `zellij` module in the list of supported terminal tools. (`supported-systems/aarch64-darwin/src/wang-lin/default.nix`, [supported-systems/aarch64-darwin/src/wang-lin/default.nixR58](diffhunk://#diff-80fa091607f0022f5215bf9e69c8ac7093fd2b605ccd9364cff9be483b24a3a5R58))

* **Core `zellij` configuration**:
  - Defined `zellij` settings, including clipboard provider, default layout, theme, and plugins. Added shell aliases (`zns`, `zas`, `zo`) for session management. (`modules/home/applications/terminal/tools/zellij/default.nix`, [modules/home/applications/terminal/tools/zellij/default.nixR1-R75](diffhunk://#diff-1fdc6d975ce735a9ae2171e8ea8cf7b41406b2627e19c4891043e9c07e2a5624R1-R75))

### Customization of `zellij`:

* **Keybindings**:
  - Added custom keybindings for pane navigation, management, tab operations, and mode switching. Configured separate keybindings for "locked," "scroll," and "renamepane" modes. (`modules/home/applications/terminal/tools/zellij/keybinds.nix`, [modules/home/applications/terminal/tools/zellij/keybinds.nixR1-R160](diffhunk://#diff-7094490e19268e50991bdbf380fc565ab789cbb9b55e381e725ca6fa723374e3R1-R160))

* **Layouts**:
  - Created a `dev` layout with tabs for project work (`nvim`), Git (`lazygit`), file management (`yazi`), and a shell (`zsh`). (`modules/home/applications/terminal/tools/zellij/layouts/dev.nix`, [modules/home/applications/terminal/tools/zellij/layouts/dev.nixR1-R98](diffhunk://#diff-e76abd96dcb9d0b726c71ba58032706c93f9c6d818fcef1a8886555751979411R1-R98))
  - Added a `system` layout with tabs for development, Git, files, shell, processes, and media management (e.g., `musikcube`, `pulsemixer`). (`modules/home/applications/terminal/tools/zellij/layouts/system.nix`, [modules/home/applications/terminal/tools/zellij/layouts/system.nixR1-R235](diffhunk://#diff-20972f3b9ea8a467d7089d8d28f488fbe25c28a2ad47785d58e6f3c46238a398R1-R235))