### PR TITLE
feat(terminal/emulators): add warp terminal

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -67,5 +67,6 @@
   applications.terminal.tools.navi.settings.style.snippet.min_width = 45;
   applications.terminal.tools.ripgrep.enable = true;
   applications.terminal.tools.yazi.enable = true;
+  applications.terminal.emulators.warp.enable = true;
   applications.terminal.tools.zellij.enable = true;
 }

--- a/modules/home/applications/terminal/emulators/warp/default.nix
+++ b/modules/home/applications/terminal/emulators/warp/default.nix
@@ -1,14 +1,32 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}: {
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.applications.terminal.emulators.warp;
+in {
   options.applications.terminal.emulators.warp = {
     enable = lib.mkEnableOption "Warp terminal emulator";
   };
 
-  config = lib.mkIf config.applications.terminal.emulators.warp.enable {
+  config = lib.mkIf cfg.enable {
     home.packages = with pkgs; [ warp-terminal ];
+    
+    home.activation = {
+      createWarpDirs = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        mkdir -p "${config.xdg.configHome}/warp"
+        mkdir -p "${config.xdg.cacheHome}/warp"
+        mkdir -p "${config.xdg.dataHome}/warp"
+        
+        if [ -d "$HOME/.warp" ] && [ ! -L "$HOME/.warp" ]; then
+          if [ -n "$(ls -A $HOME/.warp 2>/dev/null)" ]; then
+            cp -r $HOME/.warp/* "${config.xdg.configHome}/warp/" 2>/dev/null || true
+            rm -rf $HOME/.warp
+          fi
+        fi
+        
+        if [ ! -e "$HOME/.warp" ]; then
+          ln -sfn "${config.xdg.configHome}/warp" "$HOME/.warp"
+        fi
+      '';
+    };
   };
 }

--- a/modules/home/applications/terminal/emulators/warp/default.nix
+++ b/modules/home/applications/terminal/emulators/warp/default.nix
@@ -1,6 +1,9 @@
-{ config, lib, pkgs, ... }:
-
-let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
   cfg = config.applications.terminal.emulators.warp;
 in {
   options.applications.terminal.emulators.warp = {
@@ -8,21 +11,21 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = with pkgs; [ warp-terminal ];
-    
+    home.packages = with pkgs; [warp-terminal];
+
     home.activation = {
       createWarpDirs = lib.hm.dag.entryAfter ["writeBoundary"] ''
         mkdir -p "${config.xdg.configHome}/warp"
         mkdir -p "${config.xdg.cacheHome}/warp"
         mkdir -p "${config.xdg.dataHome}/warp"
-        
+
         if [ -d "$HOME/.warp" ] && [ ! -L "$HOME/.warp" ]; then
           if [ -n "$(ls -A $HOME/.warp 2>/dev/null)" ]; then
             cp -r $HOME/.warp/* "${config.xdg.configHome}/warp/" 2>/dev/null || true
             rm -rf $HOME/.warp
           fi
         fi
-        
+
         if [ ! -e "$HOME/.warp" ]; then
           ln -sfn "${config.xdg.configHome}/warp" "$HOME/.warp"
         fi

--- a/modules/home/applications/terminal/emulators/warp/default.nix
+++ b/modules/home/applications/terminal/emulators/warp/default.nix
@@ -13,14 +13,30 @@ in {
   config = lib.mkIf cfg.enable {
     home.packages = with pkgs; [warp-terminal];
 
+    # Copy themes to XDG config directory
+    xdg.configFile."warp/themes".source = ./themes;
+
     home.activation = {
       createWarpDirs = lib.hm.dag.entryAfter ["writeBoundary"] ''
         mkdir -p "${config.xdg.configHome}/warp"
         mkdir -p "${config.xdg.cacheHome}/warp"
         mkdir -p "${config.xdg.dataHome}/warp"
 
+        # Create themes directory if it doesn't exist
+        mkdir -p "${config.xdg.configHome}/warp/themes"
+
+        # Copy themes if they don't exist to allow user customization
+        if [ ! -f "${config.xdg.configHome}/warp/themes/catppuccin_mocha.yml" ]; then
+          cp -n ${./themes}/*.yml "${config.xdg.configHome}/warp/themes/" 2>/dev/null || true
+        fi
+
         if [ -d "$HOME/.warp" ] && [ ! -L "$HOME/.warp" ]; then
           if [ -n "$(ls -A $HOME/.warp 2>/dev/null)" ]; then
+            # Don't overwrite existing themes when migrating
+            if [ -d "$HOME/.warp/themes" ]; then
+              mkdir -p "${config.xdg.configHome}/warp/themes"
+              cp -n $HOME/.warp/themes/*.yml "${config.xdg.configHome}/warp/themes/" 2>/dev/null || true
+            fi
             cp -r $HOME/.warp/* "${config.xdg.configHome}/warp/" 2>/dev/null || true
             rm -rf $HOME/.warp
           fi

--- a/modules/home/applications/terminal/emulators/warp/default.nix
+++ b/modules/home/applications/terminal/emulators/warp/default.nix
@@ -1,0 +1,14 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
+  options.applications.terminal.emulators.warp = {
+    enable = lib.mkEnableOption "Warp terminal emulator";
+  };
+
+  config = lib.mkIf config.applications.terminal.emulators.warp.enable {
+    home.packages = with pkgs; [ warp-terminal ];
+  };
+}

--- a/modules/home/applications/terminal/emulators/warp/themes/catppuccin_frappe.yaml
+++ b/modules/home/applications/terminal/emulators/warp/themes/catppuccin_frappe.yaml
@@ -1,0 +1,23 @@
+background: '#303446'
+accent: '#f2d5cf'
+foreground: '#c6d0f5'
+details: darker
+terminal_colors:
+  normal:
+    black: '#51576d'
+    red: '#e78284'
+    green: '#a6d189'
+    yellow: '#e5c890'
+    blue: '#8caaee'
+    magenta: '#f4b8e4'
+    cyan: '#81c8be'
+    white: '#b5bfe2'
+  bright:
+    black: '#626880'
+    red: '#e78284'
+    green: '#a6d189'
+    yellow: '#e5c890'
+    blue: '#8caaee'
+    magenta: '#f4b8e4'
+    cyan: '#81c8be'
+    white: '#a5adce'

--- a/modules/home/applications/terminal/emulators/warp/themes/catppuccin_latte.yaml
+++ b/modules/home/applications/terminal/emulators/warp/themes/catppuccin_latte.yaml
@@ -1,0 +1,23 @@
+background: '#eff1f5'
+accent: '#dc8a78'
+foreground: '#4c4f69'
+details: lighter
+terminal_colors:
+  normal:
+    black: '#5c5f77'
+    red: '#d20f39'
+    green: '#40a02b'
+    yellow: '#df8e1d'
+    blue: '#1e66f5'
+    magenta: '#ea76cb'
+    cyan: '#179299'
+    white: '#acb0be'
+  bright:
+    black: '#6c6f85'
+    red: '#d20f39'
+    green: '#40a02b'
+    yellow: '#df8e1d'
+    blue: '#1e66f5'
+    magenta: '#ea76cb'
+    cyan: '#179299'
+    white: '#bcc0cc'

--- a/modules/home/applications/terminal/emulators/warp/themes/catppuccin_macchiato.yaml
+++ b/modules/home/applications/terminal/emulators/warp/themes/catppuccin_macchiato.yaml
@@ -1,0 +1,23 @@
+background: '#24273a'
+accent: '#f4dbd6'
+foreground: '#cad3f5'
+details: darker
+terminal_colors:
+  normal:
+    black: '#494d64'
+    red: '#ed8796'
+    green: '#a6da95'
+    yellow: '#eed49f'
+    blue: '#8aadf4'
+    magenta: '#f5bde6'
+    cyan: '#8bd5ca'
+    white: '#b8c0e0'
+  bright:
+    black: '#5b6078'
+    red: '#ed8796'
+    green: '#a6da95'
+    yellow: '#eed49f'
+    blue: '#8aadf4'
+    magenta: '#f5bde6'
+    cyan: '#8bd5ca'
+    white: '#a5adcb'

--- a/modules/home/applications/terminal/emulators/warp/themes/catppuccin_mocha.yaml
+++ b/modules/home/applications/terminal/emulators/warp/themes/catppuccin_mocha.yaml
@@ -1,0 +1,23 @@
+background: '#1e1e2e'
+accent: '#f5e0dc'
+foreground: '#cdd6f4'
+details: darker
+terminal_colors:
+  normal:
+    black: '#45475a'
+    red: '#f38ba8'
+    green: '#a6e3a1'
+    yellow: '#f9e2af'
+    blue: '#89b4fa'
+    magenta: '#f5c2e7'
+    cyan: '#94e2d5'
+    white: '#bac2de'
+  bright:
+    black: '#585b70'
+    red: '#f38ba8'
+    green: '#a6e3a1'
+    yellow: '#f9e2af'
+    blue: '#89b4fa'
+    magenta: '#f5c2e7'
+    cyan: '#94e2d5'
+    white: '#a6adc8'

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -32,6 +32,7 @@
       (map libraries.relativeToRoot [
         "modules/home/user/default.nix"
         "modules/darwin/home/default.nix"
+        "modules/home/applications/terminal/emulators/warp/default.nix"
         "modules/home/applications/terminal/tools/git/default.nix"
         "modules/home/applications/terminal/tools/starship/default.nix"
         "modules/home/applications/terminal/tools/fzf/default.nix"


### PR DESCRIPTION
This pull request introduces support for the Warp terminal emulator by adding configuration options, enabling it in the system, and integrating it into the appropriate modules. Below are the key changes grouped by theme:

### Warp Terminal Emulator Support:

* Enabled Warp terminal emulator in the `homes/aarch64-darwin/aytordev@wang-lin/default.nix` configuration. (`[homes/aarch64-darwin/aytordev@wang-lin/default.nixR70](diffhunk://#diff-37a5ba77c3f1f549db478dbdd76e424eec8cf8f646f805d75322c4f94920dc2bR70)`)
* Added a new module `modules/home/applications/terminal/emulators/warp/default.nix` to define Warp-specific options, enable the package, and handle activation logic (e.g., creating necessary directories and migrating `.warp` configurations). (`[modules/home/applications/terminal/emulators/warp/default.nixR1-R35](diffhunk://#diff-e41835193cb953820dbed66fedf6d262738147df8f0c3f47a17d52a3613c17faR1-R35)`)

### Module Integration:

* Integrated the Warp module into the system by referencing it in `supported-systems/aarch64-darwin/src/wang-lin/default.nix`. (`[supported-systems/aarch64-darwin/src/wang-lin/default.nixR35](diffhunk://#diff-80fa091607f0022f5215bf9e69c8ac7093fd2b605ccd9364cff9be483b24a3a5R35)`)