### PR TITLE
feat(comms): add discord module

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -13,6 +13,7 @@
   home.configs = {};
   applications.desktop.bars.sketchybar.enable = true;
   applications.desktop.window-manager-system.aerospace.enable = true;
+  applications.desktop.communications.discord.enable = true;
   applications.terminal.tools.git.enable = true;
   applications.terminal.tools.git.signingKey = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
   applications.terminal.shells.zsh.enable = true;

--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -14,6 +14,7 @@
   applications.desktop.bars.sketchybar.enable = true;
   applications.desktop.window-manager-system.aerospace.enable = true;
   applications.desktop.communications.discord.enable = true;
+  # applications.desktop.communications.vesktop.enable = true;
   applications.terminal.tools.git.enable = true;
   applications.terminal.tools.git.signingKey = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
   applications.terminal.shells.zsh.enable = true;

--- a/modules/home/applications/desktop/communications/discord/default.nix
+++ b/modules/home/applications/desktop/communications/discord/default.nix
@@ -1,40 +1,49 @@
-{ config, lib, pkgs, ... }:
-
-let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
   inherit (lib) mkEnableOption mkIf;
-  
+
   cfg = config.applications.desktop.communications.discord;
-  
+
   # Check if betterdiscordctl is available for the current platform
-  betterdiscordctlAvailable = pkgs.betterdiscordctl.meta.available or false && 
-    (pkgs.betterdiscordctl.meta.platforms or [])
+  betterdiscordctlAvailable =
+    pkgs.betterdiscordctl.meta.available or false
+    && (pkgs.betterdiscordctl.meta.platforms or [])
     ++ (pkgs.betterdiscordctl.meta.badPlatforms or [])
     == [];
-
 in {
   options.applications.desktop.communications.discord = {
     enable = mkEnableOption "Discord";
     canary.enable = mkEnableOption "Discord Canary";
     firefox.enable = mkEnableOption "the Firefox version of Discord";
-    enableBetterDiscord = mkEnableOption "BetterDiscord installation" // {
-      default = betterdiscordctlAvailable;
-      defaultText = lib.literalExpression "true if betterdiscordctl is available on this platform";
-      description = ''
-        Whether to install and configure BetterDiscord.
-        This is only available on platforms where betterdiscordctl is supported.
-      '';
-    };
+    enableBetterDiscord =
+      mkEnableOption "BetterDiscord installation"
+      // {
+        default = betterdiscordctlAvailable;
+        defaultText = lib.literalExpression "true if betterdiscordctl is available on this platform";
+        description = ''
+          Whether to install and configure BetterDiscord.
+          This is only available on platforms where betterdiscordctl is supported.
+        '';
+      };
   };
 
   config = mkIf cfg.enable {
     home.packages = with pkgs; [
-      (if cfg.canary.enable then khanelinix.discord-canary
-      else if cfg.firefox.enable then khanelinix.discord-firefox
-      else discord)
+      (
+        if cfg.canary.enable
+        then khanelinix.discord-canary
+        else if cfg.firefox.enable
+        then khanelinix.discord-firefox
+        else discord
+      )
     ];
 
     home.activation = mkIf (cfg.enableBetterDiscord && betterdiscordctlAvailable) {
-      betterdiscordInstall = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      betterdiscordInstall = lib.hm.dag.entryAfter ["writeBoundary"] ''
         echo "Running betterdiscord install"
         ${lib.getExe pkgs.betterdiscordctl} install || ${lib.getExe pkgs.betterdiscordctl} reinstall || true
       '';

--- a/modules/home/applications/desktop/communications/discord/default.nix
+++ b/modules/home/applications/desktop/communications/discord/default.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkEnableOption mkIf;
+  
+  cfg = config.applications.desktop.communications.discord;
+  
+  # Check if betterdiscordctl is available for the current platform
+  betterdiscordctlAvailable = pkgs.betterdiscordctl.meta.available or false && 
+    (pkgs.betterdiscordctl.meta.platforms or [])
+    ++ (pkgs.betterdiscordctl.meta.badPlatforms or [])
+    == [];
+
+in {
+  options.applications.desktop.communications.discord = {
+    enable = mkEnableOption "Discord";
+    canary.enable = mkEnableOption "Discord Canary";
+    firefox.enable = mkEnableOption "the Firefox version of Discord";
+    enableBetterDiscord = mkEnableOption "BetterDiscord installation" // {
+      default = betterdiscordctlAvailable;
+      defaultText = lib.literalExpression "true if betterdiscordctl is available on this platform";
+      description = ''
+        Whether to install and configure BetterDiscord.
+        This is only available on platforms where betterdiscordctl is supported.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      (if cfg.canary.enable then khanelinix.discord-canary
+      else if cfg.firefox.enable then khanelinix.discord-firefox
+      else discord)
+    ];
+
+    home.activation = mkIf (cfg.enableBetterDiscord && betterdiscordctlAvailable) {
+      betterdiscordInstall = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        echo "Running betterdiscord install"
+        ${lib.getExe pkgs.betterdiscordctl} install || ${lib.getExe pkgs.betterdiscordctl} reinstall || true
+      '';
+    };
+  };
+}

--- a/modules/home/applications/desktop/communications/vesktop/default.nix
+++ b/modules/home/applications/desktop/communications/vesktop/default.nix
@@ -1,0 +1,81 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkEnableOption mkIf mkOption types;
+  
+  cfg = config.applications.desktop.communications.vesktop;
+
+in {
+  options.applications.desktop.communications.vesktop = {
+    enable = mkEnableOption "Vesktop";
+    
+    package = mkOption {
+      type = types.package;
+      default = pkgs.vesktop;
+      defaultText = "pkgs.vesktop";
+      description = "The Vesktop package to use.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    
+    # For backward compatibility with existing configurations
+    programs.vesktop = {
+      enable = true;
+      package = cfg.package;
+
+      vencord = {
+        settings = {
+          autoUpdate = false;
+          autoUpdateNotification = false;
+          useQuickCss = true;
+          themeLinks = [ ];
+          eagerPatches = false;
+          enableReactDevtools = true;
+          frameless = false;
+          transparent = true;
+          winCtrlQ = false;
+          disableMinSize = true;
+          winNativeTitleBar = false;
+          
+          plugins = {
+            CommandsAPI.enabled = true;
+            MessageAccessoriesAPI.enabled = true;
+            UserSettingsAPI.enabled = true;
+            AlwaysAnimate.enabled = true;
+            AlwaysExpandRoles.enabled = true;
+            AlwaysTrust.enabled = true;
+            BetterSessions.enabled = true;
+            CrashHandler.enabled = true;
+            FixImagesQuality.enabled = true;
+            PlatformIndicators.enabled = true;
+            ReplyTimestamp.enabled = true;
+            ShowHiddenChannels.enabled = true;
+            ShowHiddenThings.enabled = true;
+            VencordToolbox.enabled = true;
+            WebKeybinds.enabled = true;
+            WebScreenShareFixes.enabled = true;
+            YoutubeAdblock.enabled = true;
+            BadgeAPI.enabled = true;
+            NoTrack = {
+              enabled = true;
+              disableAnalytics = true;
+            };
+            Settings = {
+              enabled = true;
+              settingsLocation = "aboveNitro";
+            };
+          };
+          
+          notifications = {
+            timeout = 5000;
+            position = "bottom-right";
+            useNative = "not-focused";
+            logLimit = 50;
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/home/applications/desktop/communications/vesktop/default.nix
+++ b/modules/home/applications/desktop/communications/vesktop/default.nix
@@ -1,14 +1,16 @@
-{ config, lib, pkgs, ... }:
-
-let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
   inherit (lib) mkEnableOption mkIf mkOption types;
-  
-  cfg = config.applications.desktop.communications.vesktop;
 
+  cfg = config.applications.desktop.communications.vesktop;
 in {
   options.applications.desktop.communications.vesktop = {
     enable = mkEnableOption "Vesktop";
-    
+
     package = mkOption {
       type = types.package;
       default = pkgs.vesktop;
@@ -18,8 +20,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
-    
+    home.packages = [cfg.package];
+
     # For backward compatibility with existing configurations
     programs.vesktop = {
       enable = true;
@@ -30,7 +32,7 @@ in {
           autoUpdate = false;
           autoUpdateNotification = false;
           useQuickCss = true;
-          themeLinks = [ ];
+          themeLinks = [];
           eagerPatches = false;
           enableReactDevtools = true;
           frameless = false;
@@ -38,7 +40,7 @@ in {
           winCtrlQ = false;
           disableMinSize = true;
           winNativeTitleBar = false;
-          
+
           plugins = {
             CommandsAPI.enabled = true;
             MessageAccessoriesAPI.enabled = true;
@@ -67,7 +69,7 @@ in {
               settingsLocation = "aboveNitro";
             };
           };
-          
+
           notifications = {
             timeout = 5000;
             position = "bottom-right";

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -46,6 +46,7 @@
         "modules/home/applications/terminal/tools/ssh/default.nix"
         "modules/home/applications/terminal/tools/comma/default.nix"
         "modules/home/applications/terminal/tools/direnv/default.nix"
+        "modules/home/applications/desktop/communications/discord/default.nix"
         "modules/home/applications/terminal/tools/eza/default.nix"
         "modules/home/applications/terminal/tools/fastfetch/default.nix"
         "modules/home/applications/terminal/tools/gh/default.nix"

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -47,6 +47,7 @@
         "modules/home/applications/terminal/tools/comma/default.nix"
         "modules/home/applications/terminal/tools/direnv/default.nix"
         "modules/home/applications/desktop/communications/discord/default.nix"
+        # "modules/home/applications/desktop/communications/vesktop/default.nix"
         "modules/home/applications/terminal/tools/eza/default.nix"
         "modules/home/applications/terminal/tools/fastfetch/default.nix"
         "modules/home/applications/terminal/tools/gh/default.nix"


### PR DESCRIPTION
This pull request introduces configuration modules for Discord and Vesktop desktop communication applications, and enables Discord by default for the `aarch64-darwin` system. It adds flexible options for both applications, including support for Discord variants and BetterDiscord, and provides detailed Vencord plugin settings for Vesktop. Vesktop is present but commented out, indicating it's not yet enabled by default.

**Desktop Communication Applications**

* Added a new module for configuring Discord with options for enabling the main app, Canary, Firefox version, and BetterDiscord (with platform detection for BetterDiscord support).
* Added a new module for configuring Vesktop, including detailed Vencord plugin and notification settings. The module is present but not enabled by default.

**System and Home Configuration**

* Enabled Discord in the user home configuration (`homes/aarch64-darwin/aytordev@wang-lin/default.nix`), with Vesktop present but commented out.
* Registered the new Discord module in the supported systems configuration; Vesktop module is present but commented out.