### PR TITLE
feat(launchers): add raycast launcher module

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -23,6 +23,7 @@
   # applications.desktop.communications.vesktop.enable = true;
   applications.desktop.editors.vscode.enable = true;
   applications.desktop.editors.zed.enable = true;
+  applications.desktop.launchers.raycast.enable = true;
   applications.terminal.tools.git.enable = true;
   applications.terminal.tools.git.signingKey = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
   applications.terminal.shells.zsh.enable = true;

--- a/modules/home/applications/desktop/launchers/raycast/default.nix
+++ b/modules/home/applications/desktop/launchers/raycast/default.nix
@@ -1,0 +1,29 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.applications.desktop.launchers.raycast;
+in {
+  options.applications.desktop.launchers.raycast = {
+    enable = mkEnableOption "Raycast launcher";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.raycast;
+      description = "The Raycast package to use.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [cfg.package];
+
+    # Raycast preferences can be configured here if needed
+    # home.file.".raycast" = {
+    #   source = ./raycast-config;
+    #   recursive = true;
+    # };
+  };
+}

--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -76,6 +76,7 @@
         "modules/home/applications/desktop/browsers/firefox/default.nix"
         "modules/home/applications/desktop/editors/vscode/default.nix"
         "modules/home/applications/desktop/editors/zed/default.nix"
+        "modules/home/applications/desktop/launchers/raycast/default.nix"
         "modules/home/applications/desktop/window-manager-system/aerospace/default.nix"
       ])
       ++ (map libraries.relativeToRoot [


### PR DESCRIPTION
📝 Summary
This PR implements a new home-manager module for Raycast, a productivity launcher for macOS. The module follows the existing project architecture and provides declarative configuration management.

### 🎯 Motivation
- Enables declarative installation and management of Raycast through Nix
- Maintains consistency with the existing modular home-manager structure
- Provides a foundation for future Raycast configuration options

### 🔧 Changes Made

#### New Files:
- `modules/home/applications/desktop/launchers/raycast/default.nix` - Main Raycast module
- `modules/home/applications/desktop/launchers/default.nix` - Launchers category module

#### Modified Files:
- `supported-systems/aarch64-darwin/src/wang-lin/default.nix` - Added launchers module to home-modules list
- `homes/aarch64-darwin/aytordev@wang-lin/default.nix` - Enabled Raycast for the user

### 📦 Module Features
- **Simple enable option**: `applications.desktop.launchers.raycast.enable`
- **Package customization**: Configurable package option (defaults to `pkgs.raycast`)
- **Future extensibility**: Structure ready for additional Raycast configuration options