### PR TITLE
feat(homebrew): add Spotify desktop application

### DIFF
--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -46,5 +46,5 @@ in {
   darwin.services.protonmail-bridge.enable = true;
   darwin.services.protonmail-bridge.usernameFile = "/Users/${inputs.secrets.username}/.config/protonmail-bridge/user.username";
   darwin.services.protonmail-bridge.passwordFile = "/Users/${inputs.secrets.username}/.config/protonmail-bridge/user.password";
-  homebrew.casks = ["docker-desktop" "ghostty" "sf-symbols"];
+  homebrew.casks = ["docker-desktop" "ghostty" "sf-symbols" "spotify"];
 }


### PR DESCRIPTION
## 📋 Summary
Adds Spotify to the homebrew.casks list to provide native Spotify desktop application through Homebrew Cask management.

## 🔄 Changes Made
- Added `"spotify"` to `homebrew.casks` in `supported-systems/aarch64-darwin/src/wang-lin/system/default.nix`

## 🎯 Type of Change
- [x] Feature (new functionality)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement

## 🧪 Testing
- [x] Configuration builds successfully with `just darwin-build wang-lin`
- [x] System applies cleanly with `just darwin-switch wang-lin`
- [x] Spotify installs correctly through Homebrew

## 📸 Before/After
**Before:** Only docker-desktop, ghostty, and sf-symbols in homebrew.casks
**After:** Added spotify to the list for native macOS Spotify app

## 💡 Why This Change?
- Provides official Spotify desktop application
- Maintains consistency with existing Homebrew Cask management
- Ensures native macOS integration and performance
- Simpler than terminal-based alternatives for daily use

## 🔗 Related Issues
Resolves the need for a reliable Spotify client on the system.

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes tested locally
- [x] Commit follows gitmoji convention
- [x] Branch name follows convention (feat/add-spotify-homebrew-cask)