### PR TITLE
fix(protonmail-bridge): Remove unsupported CLI auth flags and fix service configuration

### DIFF
--- a/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/system/default.nix
@@ -33,18 +33,14 @@ in {
   darwin.user.email = inputs.secrets.useremail;
   darwin.user.fullName = inputs.secrets.userfullname;
   darwin.user.uid = 501;
-  darwin.security.sops.secrets."thunderbird_protonmail_bridge_username".key = "thunderbird_protonmail_bridge_username";
-  darwin.security.sops.secrets."thunderbird_protonmail_bridge_username".sopsFile = "${sopsFolder}/shared.yaml";
-  darwin.security.sops.secrets."thunderbird_protonmail_bridge_username".path = "/Users/${inputs.secrets.username}/.config/protonmail-bridge/user.username";
-  darwin.security.sops.secrets."thunderbird_protonmail_bridge_username".owner = "${inputs.secrets.username}";
-  darwin.security.sops.secrets."thunderbird_protonmail_bridge_username".mode = "0400";
-  darwin.security.sops.secrets."thunderbird_protonmail_bridge_password".key = "thunderbird_protonmail_bridge_password";
-  darwin.security.sops.secrets."thunderbird_protonmail_bridge_password".sopsFile = "${sopsFolder}/shared.yaml";
-  darwin.security.sops.secrets."thunderbird_protonmail_bridge_password".path = "/Users/${inputs.secrets.username}/.config/protonmail-bridge/user.password";
-  darwin.security.sops.secrets."thunderbird_protonmail_bridge_password".owner = "${inputs.secrets.username}";
-  darwin.security.sops.secrets."thunderbird_protonmail_bridge_password".mode = "0400";
+  # ProtonMail Bridge configuration
+  # NOTE: ProtonMail Bridge must be configured manually first:
+  # 1. Run `protonmail-bridge` (without --noninteractive) to set up your account
+  # 2. Login with your ProtonMail credentials
+  # 3. Configure mail client settings
+  # 4. After initial setup, the service below will keep it running in background
   darwin.services.protonmail-bridge.enable = true;
-  darwin.services.protonmail-bridge.usernameFile = "/Users/${inputs.secrets.username}/.config/protonmail-bridge/user.username";
-  darwin.services.protonmail-bridge.passwordFile = "/Users/${inputs.secrets.username}/.config/protonmail-bridge/user.password";
+  darwin.services.protonmail-bridge.logLevel = "info";  # Options: panic, fatal, error, warn, info, debug
+  darwin.services.protonmail-bridge.enableGrpc = false;  # Enable if you need programmatic control
   homebrew.casks = ["docker-desktop" "ghostty" "sf-symbols" "spotify"];
 }


### PR DESCRIPTION
## Problem
- ProtonMail Bridge was failing to start due to non-existent --username-file and --password-file flags
- Service was stuck in a restart loop with "flag provided but not defined" errors
- HOME environment variable was incorrectly set to $USER literal string

## Solution
- Removed deprecated username/password options that don't exist in ProtonMail Bridge CLI
- Added proper logLevel and enableGrpc configuration options
- Fixed HOME environment variable to use actual user path via config.system.primaryUser
- Updated documentation to clarify manual initial setup requirement

## Changes
- Refactored darwin.services.protonmail-bridge module to remove auth flags
- Updated wang-lin system configuration to use new module interface
- Added clear documentation about manual bridge setup process

## Testing
- Service now starts successfully with PID and exit code 0
- IMAP port 1143 and SMTP port 1025 are listening correctly
- Service runs in background with --noninteractive flag as intended