### PR TITLE
fix(config): resolve build issues with deprecated SSH options and failing packages

### DIFF
--- a/modules/home/applications/terminal/tools/bitwarden-cli/default.nix
+++ b/modules/home/applications/terminal/tools/bitwarden-cli/default.nix
@@ -221,7 +221,7 @@ in {
   config = lib.mkIf cfg.enable {
     # Only install bitwarden-cli package if rbw is not enabled (to avoid broken package)
     # rbw can be used as a standalone alternative
-    home.packages = lib.optionals (!cfg.rbw.enable) [cfg.package] 
+    home.packages = lib.optionals (!cfg.rbw.enable) [cfg.package]
                     ++ lib.optionals cfg.rbw.enable [
                       cfg.rbw.package
                       cfg.rbw.pinentry
@@ -242,7 +242,7 @@ in {
       text = ''
         # Bitwarden CLI session management
         export BW_SESSION=""
-        
+
         # Function to unlock Bitwarden and export session
         bw-unlock() {
           export BW_SESSION=$(bw unlock --raw)
@@ -264,7 +264,7 @@ in {
             export BW_CLIENTID=$(cat "${cfg.settings.apiKey.clientIdPath or "/run/user/$UID/secrets/bitwarden_api_client_id"}")
             export BW_CLIENTSECRET=$(cat "${cfg.settings.apiKey.clientSecretPath or "/run/user/$UID/secrets/bitwarden_api_client_secret"}")
             rbw login
-          ''} 
+          ''}
           ${lib.optionalString (!cfg.settings.apiKey.useSops) ''
           if [[ -f "$HOME/.config/rbw/apikey" ]]; then
             source "$HOME/.config/rbw/apikey"
@@ -282,7 +282,7 @@ in {
         if command -v bw &> /dev/null; then
           eval "$(bw completion --shell zsh)"
         fi
-        
+
         # rbw aliases if using rbw instead of bw
         if command -v rbw &> /dev/null && ! command -v bw &> /dev/null; then
           alias bw="rbw"
@@ -309,7 +309,7 @@ in {
       text = ''
         # Bitwarden CLI session management
         export BW_SESSION=""
-        
+
         # Function to unlock Bitwarden and export session
         bw-unlock() {
           export BW_SESSION=$(bw unlock --raw)
@@ -327,7 +327,7 @@ in {
         if command -v bw &> /dev/null; then
           eval "$(bw completion --shell bash)"
         fi
-        
+
         # rbw aliases if using rbw instead of bw
         if command -v rbw &> /dev/null && ! command -v bw &> /dev/null; then
           alias bw="rbw"
@@ -354,7 +354,7 @@ in {
       text = ''
         # Bitwarden CLI session management
         set -gx BW_SESSION ""
-        
+
         # Function to unlock Bitwarden and export session
         function bw-unlock
           set -gx BW_SESSION (bw unlock --raw)
@@ -394,7 +394,7 @@ in {
         if command -v bw &> /dev/null
           bw completion --shell fish | source
         end
-        
+
         # rbw aliases if using rbw instead of bw
         if command -v rbw &> /dev/null; and not command -v bw &> /dev/null
           alias bw="rbw"
@@ -419,7 +419,7 @@ in {
 
     # Add sourcing instructions to shell configs
     programs.zsh = lib.mkIf (cfg.shellIntegration.enable && cfg.shellIntegration.enableZshIntegration) {
-      initExtra = ''
+      initContent = ''
         # Source Bitwarden CLI integration
         [[ -f "$HOME/.config/bitwarden-cli/zsh-integration.sh" ]] && source "$HOME/.config/bitwarden-cli/zsh-integration.sh"
       '';
@@ -468,10 +468,10 @@ in {
       text = ''
         #!/usr/bin/env bash
         # Helper script to unlock rbw using sops-managed API keys
-        
+
         CLIENT_ID_PATH="${cfg.settings.apiKey.clientIdPath or "/run/user/$UID/secrets/bitwarden_api_client_id"}"
         CLIENT_SECRET_PATH="${cfg.settings.apiKey.clientSecretPath or "/run/user/$UID/secrets/bitwarden_api_client_secret"}"
-        
+
         if [[ ! -f "$CLIENT_ID_PATH" ]] || [[ ! -f "$CLIENT_SECRET_PATH" ]]; then
           echo "Error: Bitwarden API keys not found in sops secrets"
           echo "Expected locations:"
@@ -483,10 +483,10 @@ in {
           echo "  bitwarden_api_client_secret: your-client-secret"
           exit 1
         fi
-        
+
         CLIENT_ID=$(cat "$CLIENT_ID_PATH")
         CLIENT_SECRET=$(cat "$CLIENT_SECRET_PATH")
-        
+
         export BW_CLIENTID="$CLIENT_ID"
         export BW_CLIENTSECRET="$CLIENT_SECRET"
         rbw login

--- a/modules/home/applications/terminal/tools/jujutsu/default.nix
+++ b/modules/home/applications/terminal/tools/jujutsu/default.nix
@@ -38,7 +38,7 @@ in {
     };
   };
   config = mkIf cfg.enable {
-    home.packages = [cfg.package pkgs.lazyjj];
+    home.packages = [cfg.package];
     programs.jujutsu = {
       enable = true;
       package = cfg.package;

--- a/modules/home/applications/terminal/tools/nh/default.nix
+++ b/modules/home/applications/terminal/tools/nh/default.nix
@@ -11,14 +11,7 @@
     clean.enable = true;
     flake = "/Users/${inputs.secrets.username}";
   };
-  nhPackage = pkgs.nh.overrideAttrs {
-    patches = [
-      (pkgs.fetchpatch {
-        url = "https://github.com/nix-community/nh/pull/340.patch";
-        hash = "sha256-AYrogYKEbwCO4MWoiGIt9I5gDv8XiPEA7DiPaYtNnD8=";
-      })
-    ];
-  };
+  nhPackage = pkgs.nh;
   nixreAlias = "nh ${
     if pkgs.stdenv.hostPlatform.isLinux
     then "os"

--- a/modules/home/applications/terminal/tools/ssh/default.nix
+++ b/modules/home/applications/terminal/tools/ssh/default.nix
@@ -70,14 +70,7 @@ in {
   config = lib.mkIf cfg.enable {
     programs.ssh = {
       enable = true;
-      forwardAgent = false;
-      compression = false;
-      serverAliveInterval = 15;
-      serverAliveCountMax = 3;
-      hashKnownHosts = false;
-      controlMaster = "auto";
-      controlPath = "~/.ssh/controlmasters/%r@%h:%p";
-      controlPersist = "10m";
+      enableDefaultConfig = false;
       extraOptionOverrides = {
         Ciphers = "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr";
         MACs = "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com";
@@ -89,6 +82,16 @@ in {
       extraConfig = cfg.extraConfig;
       matchBlocks = lib.mkMerge [
         {
+          "*" = {
+            forwardAgent = false;
+            compression = false;
+            serverAliveInterval = 15;
+            serverAliveCountMax = 3;
+            hashKnownHosts = false;
+            controlMaster = "auto";
+            controlPath = "~/.ssh/controlmasters/%r@%h:%p";
+            controlPersist = "10m";
+          };
           "*.local" = {
             user = config.home.username;
             port = cfg.port;


### PR DESCRIPTION
- Update SSH config to use modern matchBlocks structure instead of deprecated global options
- Replace deprecated programs.zsh.initExtra with initContent in bitwarden-cli
- Remove failing patch from nh package
- Temporarily remove lazyjj package due to test failures with jj CLI changes

Fixes build errors for wang-lin darwin configuration