### PR TITLE
config(wang-lin): disable Warp terminal and Sketchybar modules

### DIFF
--- a/supported-systems/aarch64-darwin/src/wang-lin/default.nix
+++ b/supported-systems/aarch64-darwin/src/wang-lin/default.nix
@@ -34,7 +34,7 @@
       (map libraries.relativeToRoot [
         "modules/home/user/default.nix"
         "modules/darwin/home/default.nix"
-        "modules/home/applications/terminal/emulators/warp/default.nix"
+        # "modules/home/applications/terminal/emulators/warp/default.nix"
         "modules/home/applications/terminal/emulators/ghostty/default.nix"
         "modules/home/applications/terminal/tools/git/default.nix"
         "modules/home/applications/terminal/tools/starship/default.nix"
@@ -71,7 +71,7 @@
         "modules/home/applications/terminal/shells/bash/default.nix"
         "modules/home/applications/terminal/shells/fish/default.nix"
         "modules/home/applications/terminal/shells/nu-shell/default.nix"
-        "modules/home/applications/desktop/bars/sketchybar/default.nix"
+        # "modules/home/applications/desktop/bars/sketchybar/default.nix"
         "modules/home/applications/desktop/browsers/chrome/default.nix"
         "modules/home/applications/desktop/browsers/chrome-dev/default.nix"
         "modules/home/applications/desktop/browsers/brave/default.nix"


### PR DESCRIPTION
- Comment out Warp terminal emulator module to disable it
- Comment out Sketchybar desktop bar module to disable it
- Keep Ghostty as the active terminal emulator

Refs system configuration cleanup