### PR TITLE
feat(zed): switch to unstable package for latest features

### DIFF
--- a/modules/home/applications/desktop/editors/zed/default.nix
+++ b/modules/home/applications/desktop/editors/zed/default.nix
@@ -16,7 +16,7 @@ in {
   config = mkIf cfg.enable {
     programs.zed-editor = {
       enable = true;
-      package = pkgs-stable.zed-editor;
+      package = pkgs.zed-editor;
 
       # Extensions - https://github.com/zed-industries/extensions/tree/main/extensions
       extensions = [


### PR DESCRIPTION
- Change from pkgs-stable.zed-editor to pkgs.zed-editor
- Use unstable Nix packages to get latest Zed editor version
- Ensures access to newest features and bug fixes

Refs editor configuration update