### PR TITLE
fix(protonmail-bridge): disable self-updater via nixpkgs overlay

### DIFF
--- a/modules/home/services/protonmail-bridge/default.nix
+++ b/modules/home/services/protonmail-bridge/default.nix
@@ -6,6 +6,34 @@
 }: let
   inherit (lib) mkIf mkEnableOption mkOption types;
   cfg = config.aytordev.services.protonmail-bridge;
+
+  # Bridge self-updater bug (root cause fixed by overlay):
+  # The upstream Darwin updater resolves os.Executable() to a Nix store path,
+  # walks up to /nix/store as the .app bundle root, and copies the entire
+  # store (~15 GB) to $TMPDIR/proton-update-source{random}/ on every hourly
+  # update check (~720 GB over 48 h). Fixed in overlays/protonmail-bridge by
+  # replacing install_darwin.go with a no-op implementation.
+  #
+  # TMPDIR redirect below is defense-in-depth only: it contains any residual
+  # writes to a bounded directory and enables the startup purge of legacy dirs.
+  bridgeTmpDir = "${config.home.homeDirectory}/.local/state/protonmail-bridge/tmp";
+
+  grpcFlag = lib.optional cfg.enableGrpc "--grpc";
+
+  startScript = pkgs.writeShellScript "protonmail-bridge-start" ''
+    /bin/wait4path /nix/store
+    mkdir -p "${bridgeTmpDir}"
+    # One-shot purge of any legacy proton-update-source* dirs accumulated
+    # before the overlay fix. Safe to remove once all hosts are updated.
+    rm -rf "${bridgeTmpDir}"/proton-update-source* 2>/dev/null || true
+
+    export TMPDIR="${bridgeTmpDir}"
+    export HOME="${config.home.homeDirectory}"
+    exec ${pkgs.protonmail-bridge}/bin/protonmail-bridge \
+      --noninteractive \
+      --log-level ${cfg.logLevel} \
+      ${lib.concatStringsSep " " grpcFlag}
+  '';
 in {
   options.aytordev.services.protonmail-bridge = {
     enable = mkEnableOption "ProtonMail Bridge";
@@ -39,27 +67,14 @@ in {
     launchd.agents.protonmail-bridge = {
       enable = true;
       config = {
-        ProgramArguments =
-          [
-            "${pkgs.protonmail-bridge}/bin/protonmail-bridge"
-            "--noninteractive"
-            "--log-level"
-            cfg.logLevel
-          ]
-          ++ (
-            if cfg.enableGrpc
-            then ["--grpc"]
-            else []
-          );
-        KeepAlive = true;
+        ProgramArguments = ["/bin/sh" "-c" "exec ${startScript}"];
+        KeepAlive = {SuccessfulExit = false;};
         RunAtLoad = true;
         ProcessType = "Background";
+        # Throttle restarts to avoid rapid crash loops saturating disk
+        ThrottleInterval = 30;
         StandardOutPath = "${config.xdg.cacheHome}/protonmail-bridge.log";
         StandardErrorPath = "${config.xdg.cacheHome}/protonmail-bridge-error.log";
-        EnvironmentVariables = {
-          # ProtonMail Bridge stores its configuration in ~/.config/protonmail/bridge-v3
-          HOME = config.home.homeDirectory;
-        };
       };
     };
   };

--- a/overlays/protonmail-bridge/default.nix
+++ b/overlays/protonmail-bridge/default.nix
@@ -1,0 +1,18 @@
+# Overlay: disable protonmail-bridge self-updater for Nix installations.
+#
+# The upstream Darwin updater (install_darwin.go) resolves os.Executable()
+# to a Nix store path, walks up to /nix/store as the .app bundle root, and
+# recursively copies the entire store (~15 GB) to $TMPDIR on every hourly
+# update check. The partial directory is never cleaned up (~720 GB / 48 h).
+#
+# Fix: replace install_darwin.go with a no-op implementation. Nix manages
+# package versions via nixos-rebuild / nix-darwin rebuild.
+_final: prev: {
+  protonmail-bridge = prev.protonmail-bridge.overrideAttrs (oldAttrs: {
+    postPatch =
+      (oldAttrs.postPatch or "")
+      + ''
+        cp ${./install_darwin.go} internal/updater/install_darwin.go
+      '';
+  });
+}

--- a/overlays/protonmail-bridge/install_darwin.go
+++ b/overlays/protonmail-bridge/install_darwin.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 Proton AG
+//
+// This file is part of Proton Mail Bridge.
+//
+// Proton Mail Bridge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Proton Mail Bridge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Proton Mail Bridge.  If not, see <https://www.gnu.org/licenses/>.
+
+// Self-update is disabled for Nix-managed installations.
+//
+// The upstream implementation resolves os.Executable() to a Nix store path
+// and walks up three directories to find the macOS .app bundle root — which
+// in a Nix installation is /nix/store. It then calls createBackup("/nix/store",
+// tempDir) which recursively copies the entire Nix store (~15 GB) to $TMPDIR
+// on every hourly update check, until hitting an irregular file (socket/pipe).
+// The partial directory is never cleaned up, accumulating ~15 GB/hr
+// (~720 GB over 48 h of uptime).
+//
+// Nix manages package versions via nixos-rebuild / nix-darwin rebuild.
+// Self-update has no valid target in a Nix store installation.
+
+package updater
+
+import (
+	"io"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ProtonMail/proton-bridge/v3/internal/versioner"
+)
+
+// InstallerDarwin is a no-op installer for Nix-managed installations.
+type InstallerDarwin struct{}
+
+// NewInstaller returns a new no-op InstallerDarwin.
+func NewInstaller(*versioner.Versioner) *InstallerDarwin {
+	return &InstallerDarwin{}
+}
+
+// InstallUpdate is intentionally a no-op. See package comment.
+func (i *InstallerDarwin) InstallUpdate(_ *semver.Version, _ io.Reader) error {
+	return nil
+}
+
+// IsAlreadyInstalled always returns false.
+func (i *InstallerDarwin) IsAlreadyInstalled(_ *semver.Version) bool {
+	return false
+}


### PR DESCRIPTION
## Problem

ProtonMail Bridge 3.21.2 installed via Nix accumulates ~15 GB/hour in `$TMPDIR`, growing to ~720 GB after ~48h of uptime. Reboot flushes `$TMPDIR` making it appear resolved.

**Root cause:** `install_darwin.go:InstallUpdate()` calls `os.Executable()` → resolves to `/nix/store/<hash>/bin/protonmail-bridge` → walks up to `/nix/store` as the "bundle root" → copies the **entire Nix store** (~15 GB of `.drv` files) to a temp dir on every hourly update check. The copy fails on the first read-only directory (`xorgproto/include`) with `EPERM`, leaving the partial dir uncleaned.

## Fix

Add `overlays/protonmail-bridge/` with a patched `install_darwin.go` where `InstallUpdate` is a no-op:

```go
func (i *InstallerDarwin) InstallUpdate(_ *semver.Version, _ io.Reader) error {
    return nil  // Nix manages versions via nix-darwin rebuild
}
```

Self-update has no valid target in a Nix store installation — `nixos-rebuild`/`darwin-rebuild` is the correct upgrade path.

Also simplify `modules/home/services/protonmail-bridge/default.nix`:
- Remove background cleanup loop (no longer needed with root cause fixed)
- Keep `TMPDIR` redirect to `~/.local/state/protonmail-bridge/tmp` as defense-in-depth
- Keep startup purge of legacy `proton-update-source*` dirs

## Verification

```
nix build .#darwinConfigurations.wang-lin.config.system.build.toplevel
```

Build passes. Patched binary contains no strings from the original `createBackup` / update-source path.