### PR TITLE
fix(brew): replace docker-desktop with podman-desktop

### DIFF
--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -18,7 +18,8 @@ in {
       desktop = enabled; # Browsers, raycast, aerospace
       development = {
         enable = true;
-        dockerEnable = true;
+        dockerEnable = false;
+        podmanEnable = true;
         gameEnable = false;
         goEnable = false;
         kubernetesEnable = true;

--- a/modules/darwin/archetypes/workstation/default.nix
+++ b/modules/darwin/archetypes/workstation/default.nix
@@ -19,7 +19,8 @@ in {
         desktop = enabled;
         development = {
           enable = true;
-          dockerEnable = true;
+          dockerEnable = false;
+          podmanEnable = true;
           aiEnable = false;
         };
         networking = enabled;

--- a/modules/darwin/suites/development/default.nix
+++ b/modules/darwin/suites/development/default.nix
@@ -8,7 +8,8 @@
 in {
   options.aytordev.suites.development = {
     enable = lib.mkEnableOption "common development configuration";
-    dockerEnable = lib.mkEnableOption "docker development configuration";
+    dockerEnable = lib.mkEnableOption "docker desktop configuration";
+    podmanEnable = lib.mkEnableOption "podman desktop configuration";
     aiEnable = lib.mkEnableOption "ai development configuration";
   };
 
@@ -23,6 +24,8 @@ in {
         ]
         ++ lib.optionals cfg.dockerEnable [
           "docker-desktop"
+        ]
+        ++ lib.optionals cfg.podmanEnable [
           "podman-desktop"
         ];
 

--- a/modules/home/suites/development/default.nix
+++ b/modules/home/suites/development/default.nix
@@ -65,6 +65,7 @@ in {
     enable = lib.mkEnableOption "common development configuration";
     azureEnable = lib.mkEnableOption "azure development configuration";
     dockerEnable = lib.mkEnableOption "docker development configuration";
+    podmanEnable = lib.mkEnableOption "podman development configuration";
     gameEnable = lib.mkEnableOption "game development configuration";
     goEnable = lib.mkEnableOption "go development configuration";
     kubernetesEnable = lib.mkEnableOption "kubernetes development configuration";
@@ -88,7 +89,7 @@ in {
         ++ lib.optionals (!isWSL) [
           bruno
         ]
-        ++ lib.optionals cfg.dockerEnable [
+        ++ lib.optionals cfg.podmanEnable [
           podman
           podman-tui
         ]
@@ -169,7 +170,7 @@ in {
             jujutsu = mkDefault enabled;
             jjui = mkDefault enabled;
             k9s.enable = mkDefault cfg.kubernetesEnable;
-            lazydocker.enable = mkDefault cfg.dockerEnable;
+            lazydocker.enable = mkDefault cfg.podmanEnable;
             lazygit = mkDefault enabled;
             # oh-my-posh = mkDefault enabled;  # TODO: module doesn't exist
           };


### PR DESCRIPTION
## Problem

`brew bundle` fails on every `darwin-rebuild switch` with:

```
Error: docker-desktop: It seems the App source '/Applications/Docker.app' is not there.
```

Docker Desktop was manually removed from `/Applications/` but remained declared as a managed Homebrew cask. Brew tries to upgrade it, can't find the `.app`, and aborts.

## Root Cause

Both `docker-desktop` and `podman-desktop` were gated behind a single `dockerEnable` flag in the development suites. This conflated two separate tools — disabling one disabled both.

## Fix

Split into two independent options across both darwin and home-manager development suite modules:

- **`dockerEnable`** → `docker-desktop` cask only
- **`podmanEnable`** → `podman-desktop` cask, `podman` + `podman-tui` packages, `lazydocker`

Updated:
- Darwin workstation archetype: `dockerEnable = false`, `podmanEnable = true`
- `wang-lin` host config: same

## Verification

`nix build .#darwinConfigurations.wang-lin.config.system.build.toplevel` passes.