### PR TITLE
:bug: fix(sketchybar): resolve Lua 5.5 compatibility and startup errors

### DIFF
--- a/modules/home/programs/desktop/bars/sketchybar/config/.luarc.json
+++ b/modules/home/programs/desktop/bars/sketchybar/config/.luarc.json
@@ -1,0 +1,5 @@
+{
+  "diagnostics": {
+    "globals": ["sbar"]
+  }
+}

--- a/modules/home/programs/desktop/bars/sketchybar/config/items/widgets/brew.lua
+++ b/modules/home/programs/desktop/bars/sketchybar/config/items/widgets/brew.lua
@@ -41,7 +41,11 @@ local function is_package_line(line)
 end
 
 local function update_brew()
-	local brew_cmd = '/bin/zsh -c "brew outdated -q"'
+	local brew_bin = "/opt/homebrew/bin/brew"
+	if not io.open(brew_bin) then
+		brew_bin = "/usr/local/bin/brew"
+	end
+	local brew_cmd = "/bin/zsh -c '" .. brew_bin .. " outdated -q 2>/dev/null'"
 
 	-- print("[BREW OUTDATED] Running command: " .. brew_cmd)
 

--- a/modules/home/programs/desktop/bars/sketchybar/config/items/workspaces.lua
+++ b/modules/home/programs/desktop/bars/sketchybar/config/items/workspaces.lua
@@ -316,7 +316,7 @@ local function initialize_workspaces()
 			local ws_icon = space_icons[workspace_index] or workspace_index
 			local ws_color = space_colors[workspace_index] or colors.white
 
-			local workspace = sbar.add("item", {
+			local workspace = sbar.add("item", "space." .. workspace_index, {
 				click_script = "aerospace workspace " .. workspace_index .. " 2>/dev/null",
 				drawing = false,
 				background = { drawing = false },

--- a/modules/home/programs/desktop/bars/sketchybar/default.nix
+++ b/modules/home/programs/desktop/bars/sketchybar/default.nix
@@ -7,7 +7,14 @@
   cfg = config.aytordev.programs.desktop.bars.sketchybar;
   themeCfg = config.aytordev.theme;
 
-  luaGen = import ./lua-gen.nix {inherit lib pkgs cfg themeCfg;};
+  luaGen = import ./lua-gen.nix {
+    inherit
+      lib
+      pkgs
+      cfg
+      themeCfg
+      ;
+  };
 in {
   options.aytordev.programs.desktop.bars.sketchybar =
     import ./options.nix {inherit lib;}
@@ -34,8 +41,29 @@ in {
       sbarLuaPackage = pkgs.sbarlua;
       extraPackages = luaGen.allPackages;
 
-      extraLuaPackages = luaPkgs: [
-        pkgs.aytordev.luaposix
+      extraLuaPackages = luaPkgs: let
+        patchedRockspec = pkgs.runCommand "luaposix-36.2.1-1.rockspec" {} ''
+          sed 's/lua >= 5.1, < 5.5/lua >= 5.1/' ${
+            pkgs.fetchurl {
+              url = "https://luarocks.org/manifests/gvvaughan/luaposix-36.2.1-1.rockspec";
+              hash = "sha256-mlv8WUAdD+pfMUXGVh3zGgknfMoKDzFcyoeOyEtJj1Y=";
+            }
+          } > $out
+        '';
+        luaposix = luaPkgs.buildLuarocksPackage {
+          pname = "luaposix";
+          version = "36.2.1";
+          src = pkgs.fetchFromGitHub {
+            owner = "luaposix";
+            repo = "luaposix";
+            rev = "v36.2.1";
+            hash = "sha256-oxHH7RmaEGLU1tSlFhtf7F6CKOSRaNamq7QxtWyfwtI=";
+          };
+          knownRockspec = patchedRockspec.outPath;
+          disabled = false;
+        };
+      in [
+        luaposix
         luaPkgs.dkjson
         luaPkgs.lua-cjson
       ];

--- a/packages/luaposix/package.nix
+++ b/packages/luaposix/package.nix
@@ -1,28 +1,27 @@
-{pkgs, ...}:
-pkgs.lua54Packages.buildLuarocksPackage {
-  pname = "luaposix";
-  version = "36.2.1";
-
-  # Use git source to avoid src.rock directory structure issues
-  src = pkgs.fetchFromGitHub {
-    owner = "luaposix";
-    repo = "luaposix";
-    rev = "v36.2.1";
-    hash = "sha256-oxHH7RmaEGLU1tSlFhtf7F6CKOSRaNamq7QxtWyfwtI=";
-  };
-
-  knownRockspec =
-    (pkgs.fetchurl {
-      url = "https://luarocks.org/manifests/gvvaughan/luaposix-36.2.1-1.rockspec";
-      hash = "sha256-mlv8WUAdD+pfMUXGVh3zGgknfMoKDzFcyoeOyEtJj1Y=";
-    }).outPath;
-
-  # Fix rockspec to assume we are at root
-  preBuild = ''
-    # The rockspec expects to be able to run build-aux/luke
-    # Check if we are in the right directory
-    ls -la
+{pkgs, ...}: let
+  # luaposix 36.2.1 rockspec declares "lua >= 5.1, < 5.5" but the code is
+  # compatible with 5.5. Patch the upper bound before luarocks processes it.
+  patchedRockspec = pkgs.runCommand "luaposix-36.2.1-1.rockspec" {} ''
+    sed 's/lua >= 5.1, < 5.5/lua >= 5.1/' ${
+      pkgs.fetchurl {
+        url = "https://luarocks.org/manifests/gvvaughan/luaposix-36.2.1-1.rockspec";
+        hash = "sha256-mlv8WUAdD+pfMUXGVh3zGgknfMoKDzFcyoeOyEtJj1Y=";
+      }
+    } > $out
   '';
+in
+  pkgs.lua55Packages.buildLuarocksPackage {
+    pname = "luaposix";
+    version = "36.2.1";
 
-  disabled = false;
-}
+    src = pkgs.fetchFromGitHub {
+      owner = "luaposix";
+      repo = "luaposix";
+      rev = "v36.2.1";
+      hash = "sha256-oxHH7RmaEGLU1tSlFhtf7F6CKOSRaNamq7QxtWyfwtI=";
+    };
+
+    knownRockspec = patchedRockspec.outPath;
+
+    disabled = false;
+  }


### PR DESCRIPTION
## Summary

Fixes three separate bugs that caused SketchyBar to not display (bar with `drawing: off`, 0 items) and produce startup errors.

## Root Causes & Fixes

### 1. Barra invisible — luaposix compilado para Lua 5.4

`sbarlua` se actualizó a Lua 5.5 (2026-03-06) pero `pkgs.aytordev.luaposix` seguía produciendo `lua5.4-luaposix`. Los `.so` aterrizaban en `lib/lua/5.4/` en lugar de `lib/lua/5.5/`, así que `require('posix.sys.socket')` fallaba al inicio — el script crasheaba antes de aplicar ninguna configuración, dejando la barra con `drawing: off` y 0 items.

**Fix**: Construir luaposix inline en `extraLuaPackages` usando `luaPkgs.buildLuarocksPackage` (el Lua 5.5 de sbarlua). El upper bound `lua >= 5.1, < 5.5` del rockspec se parchea eliminándolo — el código es compatible con 5.5. Se actualiza también `packages/luaposix/package.nix` para consistencia.

### 2. Brew widget — `brew: command not found`

El wrapper de sketchybar añade `/opt/homebrew/bin` al PATH sin separador `:` (`PATH=$PATH'/opt/homebrew/bin'`), haciendo brew inaccesible en subshells.

**Fix**: Detectar el binario de brew por path absoluto en runtime (`/opt/homebrew/bin/brew` con fallback a `/usr/local/bin/brew`).

### 3. Workspace items — `[!] Order: Item '/space\..*/' not found`

Los items de workspace se creaban sin nombre (`sbar.add("item", { ... })`), así que el comando de reorder nunca encontraba el patrón `/space\..*/`.

**Fix**: Nombrar cada workspace item como `space.<index>` para que coincida con el patrón del reorder.

## Changes

- `modules/home/programs/desktop/bars/sketchybar/default.nix` — inline luaposix build for sbarlua's Lua 5.5
- `packages/luaposix/package.nix` — update to lua55Packages + patched rockspec
- `config/items/widgets/brew.lua` — absolute brew path with runtime detection
- `config/items/workspaces.lua` — name items `space.<index>`
- `config/.luarc.json` — declare `sbar` as LSP global to suppress false positives