### PR TITLE
feat(terminal-tools): apply khanelinix upstream improvements

### DIFF
--- a/modules/home/programs/terminal/tools/atuin/default.nix
+++ b/modules/home/programs/terminal/tools/atuin/default.nix
@@ -42,6 +42,9 @@ in {
         ];
       };
     };
+    home.shellAliases = {
+      atuin-prune-failed = "atuin search --exclude-exit 0 --delete";
+    };
     xdg.configFile."bash/conf.d/atuin.sh" = lib.mkIf cfg.enableBashIntegration {
       text = ''
         eval "$(atuin init bash)"

--- a/modules/home/programs/terminal/tools/gh/default.nix
+++ b/modules/home/programs/terminal/tools/gh/default.nix
@@ -4,7 +4,13 @@
   pkgs,
   ...
 }: let
-  inherit (lib) mkIf mkEnableOption mkOption types;
+  inherit
+    (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    ;
   cfg = config.aytordev.programs.terminal.tools.gh;
   hasToken = cfg.auth.tokenPath != null;
 in {
@@ -39,17 +45,16 @@ in {
     };
   };
   config = mkIf cfg.enable {
-    home.packages = with pkgs; [
-      gh
-      gh-eco
-      gh-cal
-      gh-poi
-      gh-notify
-      gh-dash
-    ];
     programs = {
       gh = {
         enable = true;
+        extensions = with pkgs; [
+          gh-eco
+          gh-cal
+          gh-poi
+          gh-notify
+          gh-dash
+        ];
         gitCredentialHelper = {
           enable = true;
           inherit (cfg.gitCredentialHelper) hosts;

--- a/modules/home/programs/terminal/tools/git/default.nix
+++ b/modules/home/programs/terminal/tools/git/default.nix
@@ -21,9 +21,15 @@
   ];
   gitConfig = {
     enable = true;
-    package = pkgs.git;
+    package = pkgs.gitFull;
     inherit ignores;
     maintenance.enable = true;
+    hooks.pre-commit = pkgs.writeShellScript "git-pre-commit-conflict-check" ''
+      if git diff --cached | grep -qE '^\+(<{7}|>{7})'; then
+        printf 'Error: staged changes contain conflict markers\n' >&2
+        exit 1
+      fi
+    '';
     settings = {
       alias = aliases;
       user = {
@@ -43,6 +49,10 @@
       };
       rerere.enabled = true;
       rebase.autostash = true;
+      credential.helper =
+        if pkgs.stdenv.hostPlatform.isDarwin
+        then "osxkeychain"
+        else "${pkgs.gitFull}/libexec/git-core/git-credential-libsecret";
       safe.directory = [
         "/Users/${inputs.secrets.username}/"
         "/etc/nixos"
@@ -87,46 +97,48 @@ in {
     cfg = config.aytordev.programs.terminal.tools.git;
     bashConfigDir = "${config.xdg.configHome}/bash/conf.d";
   in
-    lib.mkIf cfg.enable (lib.mkMerge [
-      {
-        home.packages = gitPackages;
-        programs = {
-          git = gitConfig;
-          delta = {
-            enable = true;
-            enableGitIntegration = true;
-            options = {
-              dark = true;
-              features = mkForce "decorations side-by-side navigate";
-              plus-style = "syntax #2B3328";
-              minus-style = "syntax #3C2C2E";
-              plus-emph-style = "syntax #76946a";
-              minus-emph-style = "syntax #c34043";
-              line-numbers = true;
-              navigate = true;
-              side-by-side = true;
+    lib.mkIf cfg.enable (
+      lib.mkMerge [
+        {
+          home.packages = gitPackages;
+          programs = {
+            git = gitConfig;
+            delta = {
+              enable = true;
+              enableGitIntegration = true;
+              options = {
+                dark = true;
+                features = mkForce "decorations side-by-side navigate";
+                plus-style = "syntax #2B3328";
+                minus-style = "syntax #3C2C2E";
+                plus-emph-style = "syntax #76946a";
+                minus-emph-style = "syntax #c34043";
+                line-numbers = true;
+                navigate = true;
+                side-by-side = true;
+              };
+            };
+            difftastic = {
+              git.diffToolMode = true;
+              options = {
+                background = "dark";
+                display = "inline";
+              };
+            };
+            mergiraf = {
+              enable = true;
+              enableGitIntegration = true;
+              enableJujutsuIntegration = true;
             };
           };
-          difftastic = {
-            git.diffToolMode = true;
-            options = {
-              background = "dark";
-              display = "inline";
-            };
+        }
+        (lib.mkIf (shell-aliases.allAliases != {}) {
+          home.file."${bashConfigDir}/git-aliases.sh" = {
+            text = shell-aliases.generateGitAliasesFile shell-aliases.allAliases;
+            executable = true;
           };
-          mergiraf = {
-            enable = true;
-            enableGitIntegration = true;
-            enableJujutsuIntegration = true;
-          };
-        };
-      }
-      (lib.mkIf (shell-aliases.allAliases != {}) {
-        home.file."${bashConfigDir}/git-aliases.sh" = {
-          text = shell-aliases.generateGitAliasesFile shell-aliases.allAliases;
-          executable = true;
-        };
-        home.shellAliases = shell-aliases.allAliases;
-      })
-    ]);
+          home.shellAliases = shell-aliases.allAliases;
+        })
+      ]
+    );
 }

--- a/modules/home/programs/terminal/tools/jujutsu/default.nix
+++ b/modules/home/programs/terminal/tools/jujutsu/default.nix
@@ -5,7 +5,15 @@
   inputs,
   ...
 }: let
-  inherit (lib) mkIf mkEnableOption mkOption literalExpression optionalAttrs types;
+  inherit
+    (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    literalExpression
+    optionalAttrs
+    types
+    ;
   cfg = config.aytordev.programs.terminal.tools.jujutsu;
 in {
   options.aytordev.programs.terminal.tools.jujutsu = {
@@ -38,7 +46,11 @@ in {
     };
   };
   config = mkIf cfg.enable {
-    home.packages = [cfg.package];
+    home.packages = [
+      cfg.package
+      pkgs.lazyjj
+    ];
+    home.sessionVariables.RAYON_NUM_THREADS = "4";
     programs.jujutsu = {
       enable = true;
       inherit (cfg) package;
@@ -55,9 +67,18 @@ in {
             default = "current";
           };
           rebase.auto_stash = true;
+          ui = {
+            default-command = "log";
+            diff-editor = ":builtin";
+            diff-instructions = false;
+          };
         }
         // optionalAttrs cfg.signByDefault {
-          operation.signing_key = cfg.signingKey;
+          signing = {
+            backend = "ssh";
+            key = cfg.signingKey;
+            sign-all = true;
+          };
         };
     };
   };

--- a/modules/home/programs/terminal/tools/lazygit/custom-commands.nix
+++ b/modules/home/programs/terminal/tools/lazygit/custom-commands.nix
@@ -1,0 +1,328 @@
+[
+  {
+    key = "<c-v>";
+    context = "global";
+    description = "Create conventional commit";
+    loadingText = "Creating conventional commit...";
+    command = "git commit --message '{{.Form.Type}}{{ if .Form.Scope }}({{ .Form.Scope }}){{ end }}{{.Form.Breaking}}: {{.Form.Message}}'{{ if .Form.Body }} --message {{ .Form.Body | quote }}{{ end }}";
+    prompts = [
+      {
+        type = "menu";
+        key = "Type";
+        title = "Type of change";
+        options = [
+          {
+            name = "feat";
+            description = "A new feature";
+            value = "feat";
+          }
+          {
+            name = "fix";
+            description = "A bug fix";
+            value = "fix";
+          }
+          {
+            name = "docs";
+            description = "Documentation only changes";
+            value = "docs";
+          }
+          {
+            name = "style";
+            description = "Changes that do not affect the meaning of the code";
+            value = "style";
+          }
+          {
+            name = "refactor";
+            description = "A code change that neither fixes a bug nor adds a feature";
+            value = "refactor";
+          }
+          {
+            name = "perf";
+            description = "A code change that improves performance";
+            value = "perf";
+          }
+          {
+            name = "test";
+            description = "Adding missing tests or correcting existing tests";
+            value = "test";
+          }
+          {
+            name = "build";
+            description = "Changes that affect the build system or external dependencies";
+            value = "build";
+          }
+          {
+            name = "ci";
+            description = "Changes to CI configuration files and scripts";
+            value = "ci";
+          }
+          {
+            name = "chore";
+            description = "Other changes that don't modify src or test files";
+            value = "chore";
+          }
+          {
+            name = "revert";
+            description = "Reverts a previous commit";
+            value = "revert";
+          }
+        ];
+      }
+      {
+        type = "input";
+        title = "Scope (optional)";
+        key = "Scope";
+        initialValue = "";
+      }
+      {
+        type = "menu";
+        key = "Breaking";
+        title = "Breaking change?";
+        options = [
+          {
+            name = "no";
+            value = "";
+          }
+          {
+            name = "yes";
+            value = "!";
+          }
+        ];
+      }
+      {
+        type = "input";
+        title = "Commit subject";
+        key = "Message";
+        initialValue = "";
+      }
+      {
+        type = "input";
+        title = "Commit body (optional)";
+        key = "Body";
+        initialValue = "";
+      }
+      {
+        type = "confirm";
+        key = "Confirm";
+        title = "Commit";
+        body = "Are you sure you want to commit?";
+      }
+    ];
+  }
+
+  {
+    key = "S";
+    context = "commits";
+    description = "Autosquash recent fixup/squash commits (last 100 commits)";
+    loadingText = "Autosquashing fixup commits...";
+    output = "log";
+    command = ''
+      set -eu
+
+      if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+        echo "No commits found on this branch."
+        exit 1
+      fi
+
+      maxScanCommits=100
+
+      workDir="''${TMPDIR:-/tmp}/lazygit-autosquash-$$"
+      rm -rf "$workDir"
+      mkdir -p "$workDir"
+      trap 'rm -rf "$workDir"' EXIT HUP INT TERM
+
+      historyFile="$workDir/history"
+      latestFile="$workDir/latest"
+      orderFile="$workDir/order"
+      usedFile="$workDir/used"
+      tab="$(printf '\t')"
+
+      : > "$latestFile"
+      : > "$orderFile"
+      : > "$usedFile"
+
+      git --no-pager log --reverse -n "$maxScanCommits" --format='%H%x09%s' HEAD > "$historyFile"
+
+      fixupCount=0
+      resolvedCount=0
+
+      while IFS= read -r line; do
+        sha="''${line%%"$tab"*}"
+        subject="''${line#*"$tab"}"
+
+        case "$subject" in
+          "fixup! "*)
+            fixupCount=$((fixupCount + 1))
+            targetSubject="''${subject#fixup! }"
+            ;;
+          "squash! "*)
+            fixupCount=$((fixupCount + 1))
+            targetSubject="''${subject#squash! }"
+            ;;
+          *)
+            printf '%s\t%s\n' "$sha" "$subject" >> "$latestFile"
+            printf '%s\n' "$sha" >> "$orderFile"
+            continue
+            ;;
+        esac
+
+        targetSha=""
+        while IFS= read -r entry; do
+          entrySha="''${entry%%"$tab"*}"
+          entrySubject="''${entry#*"$tab"}"
+
+          if [ "$entrySubject" = "$targetSubject" ]; then
+            targetSha="$entrySha"
+          fi
+        done < "$latestFile"
+
+        if [ -n "$targetSha" ]; then
+          resolvedCount=$((resolvedCount + 1))
+          printf '%s\n' "$targetSha" >> "$usedFile"
+        fi
+      done < "$historyFile"
+
+      if [ "$fixupCount" -eq 0 ]; then
+        echo "No fixup!/squash! commits found in the last $maxScanCommits commits."
+        exit 1
+      fi
+
+      if [ "$resolvedCount" -eq 0 ]; then
+        echo "Found fixup!/squash! commits in the last $maxScanCommits commits, but none target commits in that window."
+        exit 1
+      fi
+
+      oldestTargetSha=""
+      while IFS= read -r candidateSha; do
+        targetUsed=0
+
+        while IFS= read -r usedSha; do
+          if [ "$usedSha" = "$candidateSha" ]; then
+            targetUsed=1
+            break
+          fi
+        done < "$usedFile"
+
+        if [ "$targetUsed" -eq 1 ]; then
+          oldestTargetSha="$candidateSha"
+          break
+        fi
+      done < "$orderFile"
+
+      if [ -z "$oldestTargetSha" ]; then
+        echo "Unable to determine the oldest fixup target commit."
+        exit 1
+      fi
+
+      if git rev-parse --verify "$oldestTargetSha^" >/dev/null 2>&1; then
+        GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash --no-verify "$oldestTargetSha^"
+      else
+        GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash --no-verify --root
+      fi
+    '';
+    prompts = [
+      {
+        type = "confirm";
+        key = "ConfirmAutosquash";
+        title = "Rewrite commit history?";
+        body = "This searches the last 100 commits, rebases from the oldest fixup target it finds, and rewrites commit hashes.";
+      }
+    ];
+  }
+
+  {
+    key = "G";
+    context = "localBranches";
+    command = "gh pr view -w {{.SelectedLocalBranch.Name}}";
+    description = "Open GitHub PR in browser";
+  }
+  {
+    key = "G";
+    context = "commits";
+    command = "gh pr view -w";
+    description = "Open GitHub PR in browser";
+  }
+
+  {
+    key = "V";
+    context = "localBranches";
+    loadingText = "Checking out GitHub Pull Request...";
+    command = "gh pr checkout {{.Form.PullRequestNumber}}";
+    description = "Checkout GitHub PR";
+    prompts = [
+      {
+        type = "menuFromCommand";
+        title = "Which PR do you want to check out?";
+        key = "PullRequestNumber";
+        command = "gh pr list --json number,title,headRefName,updatedAt --template '{{range .}}{{printf \"#%v: %s - %s (%s)\n\" .number .title .headRefName (timeago .updatedAt)}}{{end}}'";
+        filter = "#(?P<number>[0-9]+): (?P<title>.+) - (?P<ref_name>[^ ]+).*";
+        valueFormat = "{{.number}}";
+        labelFormat = "{{\"#\" | black | bold}}{{.number | white | bold}} {{.title | yellow | bold}}{{\" [\" | black | bold}}{{.ref_name | green}}{{\"]\" | black | bold}}";
+      }
+    ];
+  }
+
+  {
+    key = "<c-g>";
+    context = "localBranches";
+    command = "git fetch -p && for branch in $(git for-each-ref --format '%(refname) %(upstream:track)' refs/heads | awk '$2 == \"[gone]\" {sub(\"refs/heads/\", \"\", $1); print $1}'); do git branch -D $branch; done";
+    description = "Prune local branches no longer on remote (gone)";
+    loadingText = "Pruning gone branches...";
+  }
+
+  {
+    key = "<c-l>";
+    context = "global";
+    description = "Remove current repo index.lock";
+    loadingText = "Removing index.lock...";
+    output = "log";
+    command = ''
+      set -eu
+
+      lockFile="$(git rev-parse --git-path index.lock)"
+
+      if [ ! -e "$lockFile" ]; then
+        echo "No index.lock file found for this repo."
+        exit 1
+      fi
+
+      rm -f "$lockFile"
+      echo "Removed $lockFile"
+    '';
+    prompts = [
+      {
+        type = "confirm";
+        key = "ConfirmRemoveIndexLock";
+        title = "Remove index.lock?";
+        body = "This deletes the current repo's Git index lock file. Only continue if no other Git process is using it.";
+      }
+    ];
+  }
+
+  {
+    key = "<c-o>";
+    context = "global";
+    description = "Push to a specific remote repository";
+    loadingText = "Pushing...";
+    command = "git {{index .PromptResponses 1}} {{index .PromptResponses 0}}";
+    prompts = [
+      {
+        type = "menuFromCommand";
+        title = "Which remote repository to push to?";
+        command = "bash -c \"git remote --verbose | grep '/.* (push)'\"";
+        filter = "(?P<remote>.*)\\s+(?P<url>.*) \\(push\\)";
+        valueFormat = "{{ .remote }}";
+        labelFormat = "{{ .remote | bold | cyan }} {{ .url }}";
+      }
+      {
+        type = "menu";
+        title = "How to push?";
+        options = [
+          {value = "push";}
+          {value = "push --force-with-lease";}
+          {value = "push --force";}
+        ];
+      }
+    ];
+  }
+]

--- a/modules/home/programs/terminal/tools/lazygit/default.nix
+++ b/modules/home/programs/terminal/tools/lazygit/default.nix
@@ -15,6 +15,7 @@
     programs.lazygit = {
       enable = true;
       settings = {
+        customCommands = import ./custom-commands.nix;
         gui = {
           authorColors = {
             "${inputs.secrets.userfullname}" = "#957fb8";
@@ -26,9 +27,19 @@
             dev = "#7e9cd8";
           };
           nerdFontsVersion = "3";
+          showListFooter = false;
+          showRandomTip = false;
+          expandFocusedSidePanel = true;
         };
         git = {
           overrideGpg = true;
+          mainBranches = [
+            "main"
+            "master"
+          ];
+        };
+        os = {
+          editPreset = "nvim";
         };
       };
     };

--- a/modules/home/programs/terminal/tools/nh/default.nix
+++ b/modules/home/programs/terminal/tools/nh/default.nix
@@ -17,6 +17,16 @@
     then "os"
     else "darwin"
   } switch";
+  nixrbAlias = "nh ${
+    if pkgs.stdenv.hostPlatform.isLinux
+    then "os"
+    else "darwin"
+  } boot";
+  nixrtAlias = "nh ${
+    if pkgs.stdenv.hostPlatform.isLinux
+    then "os"
+    else "darwin"
+  } test";
 in {
   options.aytordev.programs.terminal.tools.nh = {
     enable = lib.mkEnableOption "nh";
@@ -44,7 +54,11 @@ in {
       sessionVariables = {
         NH_SEARCH_PLATFORM = 1;
       };
-      shellAliases.nixre = nixreAlias;
+      shellAliases = {
+        nixre = nixreAlias;
+        nixrb = nixrbAlias;
+        nixrt = nixrtAlias;
+      };
     };
   };
 }

--- a/modules/home/programs/terminal/tools/opencode/default.nix
+++ b/modules/home/programs/terminal/tools/opencode/default.nix
@@ -51,6 +51,12 @@ in {
   };
 
   config = mkIf cfg.enable {
+    home.shellAliases = {
+      oc = "opencode";
+      oc-sonnet = "opencode run -m anthropic/claude-sonnet-4-6";
+      oc-opus = "opencode run -m anthropic/claude-opus-4-7";
+      oc-haiku = "opencode run -m anthropic/claude-haiku-4-5-20251001";
+    };
     programs.opencode = {
       enable = true;
 

--- a/modules/home/programs/terminal/tools/tmux/default.nix
+++ b/modules/home/programs/terminal/tools/tmux/default.nix
@@ -20,6 +20,7 @@ in {
       keyMode = "vi";
       mouse = true;
       prefix = "C-a";
+      secureSocket = true;
       sensibleOnTop = false;
       terminal = "tmux-256color";
 
@@ -35,6 +36,32 @@ in {
 
         # Tmux Resurrect
         {plugin = resurrect;}
+
+        # Continuous saving of tmux environment
+        {
+          plugin = continuum;
+          extraConfig = ''
+            set -g @continuum-restore 'on'
+            set -g @continuum-save-interval '10'
+          '';
+        }
+
+        # Floating pane
+        {
+          plugin = tmux-floax;
+          extraConfig = ''
+            set -g @floax-bind 'p'
+            set -g @floax-change-path 'true'
+          '';
+        }
+
+        # Session manager with fuzzy finding
+        {
+          plugin = tmux-sessionx;
+          extraConfig = ''
+            set -g @sessionx-bind 'o'
+          '';
+        }
 
         # Which Key
         {plugin = tmux-which-key;}
@@ -78,12 +105,29 @@ in {
           # Kill all sessions except current
           bind K confirm-before -p "Kill all other sessions? (y/n)" "kill-session -a"
 
+          # Pane navigation
+          bind h select-pane -L
+          bind j select-pane -D
+          bind k select-pane -U
+          bind l select-pane -R
+
           # --- Floating Scratchpad ---
           bind-key -n M-g if-shell -F '#{==:#{session_name},scratch}' {
             detach-client
           } {
             display-popup -d "#{pane_current_path}" -E "tmux new-session -A -s scratch"
           }
+
+          # --- Performance ---
+          set -sg escape-time 0
+          set -g  history-limit 50000
+          set -g  aggressive-resize on
+
+          # --- Session Options ---
+          set -g detach-on-destroy off
+          set -g renumber-windows  on
+          set -g allow-passthrough on
+          set -g focus-events      on
 
           # --- Status Bar ---
           set -g status-position top

--- a/modules/home/programs/terminal/tools/yazi/default.nix
+++ b/modules/home/programs/terminal/tools/yazi/default.nix
@@ -18,6 +18,13 @@ in {
       optionalPluginPackage "ouch" pkgs.ouch
       ++ optionalPluginPackage "glow" pkgs.glow
       ++ optionalPluginPackage "duckdb" pkgs.duckdb
+      ++ [
+        pkgs._7zz-rar
+        pkgs.atool
+        pkgs.exiftool
+        pkgs.mediainfo
+        pkgs.unar
+      ]
       ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
         pkgs.xdragon
       ];
@@ -56,6 +63,7 @@ in {
           jump-to-char
           mount
           ouch
+          piper
           restore
           smart-enter
           smart-filter


### PR DESCRIPTION
## Summary

Applies high-value configuration improvements to 10 terminal tool modules, sourced from a cross-reference with the [khanelinix](https://github.com/khaneliman/khanelinix) upstream. Changes are grouped in three logical phases by risk profile, shipped as a single PR.

## Phase 1 — Quick Wins

**git**
- Switch from `pkgs.git` to `pkgs.gitFull`
- Add platform-conditional credential helper (`osxkeychain` on Darwin, `git-credential-libsecret` on Linux)
- Add pre-commit hook that aborts commits containing unresolved conflict markers

**nh**
- Add `nixrb` (boot) and `nixrt` (test) rebuild aliases alongside existing `nixre`

**atuin**
- Add `atuin-prune-failed` alias to remove failed-exit-status entries from history

**gh**
- Migrate extensions from bare `home.packages` to declarative `programs.gh.extensions` list

**opencode**
- Add model shorthand aliases: `oc`, `oc-sonnet`, `oc-opus`, `oc-haiku`

## Phase 2 — Deep Config

**lazygit**
- New `custom-commands.nix` with 7 command groups: conventional commits wizard (`<c-v>`), autosquash fixup (`S`), GitHub PR open (`G`) and checkout (`V`), branch prune (`<c-g>`), index.lock removal (`<c-l>`), push to specific remote (`<c-o>`)
- UI flags: `showListFooter = false`, `showRandomTip = false`, `expandFocusedSidePanel = true`, `editPreset = "nvim"`, `mainBranches`

**jujutsu**
- Add `lazyjj` TUI package
- Add `RAYON_NUM_THREADS = "4"` session variable (macOS hang workaround for upstream issue #4508)
- UI config: `default-command = "log"`, `diff-editor = ":builtin"`, `diff-instructions = false`
- Fix signing config: replace incorrect `operation.signing_key` with proper `signing.{backend,key,sign-all}`

## Phase 3 — Plugins and Extras

**tmux**
- New plugins: `continuum` (auto-save sessions every 10 min), `tmux-floax` (floating pane, `<prefix>p`), `tmux-sessionx` (session picker, `<prefix>o`)
- `hjkl` pane navigation keybindings
- Performance flags: `escape-time = 0`, `history-limit = 50000`, `aggressive-resize = on`, `secureSocket = true`
- Session options: `detach-on-destroy off`, `renumber-windows on`, `allow-passthrough on`, `focus-events on`

**yazi**
- Add packages: `_7zz-rar` (RAR archive support), `atool`, `exiftool`, `mediainfo`, `unar`
- Add `piper` plugin

## Out of Scope
SSH hardening, starship, fzf multi-shell, direnv whitelist — already ahead of khanelinix in these areas.

## Verified
- `nix fmt` passes
- `nix build .#darwinConfigurations.wang-lin.config.system.build.toplevel` passes (88 derivations)