### PR TITLE
feat(ssh): add Hetzner portfolio VPS known host and sops secret

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778876681,
-        "narHash": "sha256-9XOIxYLBp+sJsPWNnNyk1aVfYXuuRJZ4Anpplm9Tn8g=",
+        "lastModified": 1779213149,
+        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7fad8197070948d8aa02cb8922240ee129cab2e",
+        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778810872,
-        "narHash": "sha256-mmYGeJPaKHoBmf1jjDKAduMEVsi3WvTdX0jCtbANcw4=",
+        "lastModified": 1779201614,
+        "narHash": "sha256-AFcjCGsu40BwdxjFicL4X6i56XrmACAQW9xPUNU9r4Y=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "4954461ef00c209f60ce911ec4b731ed7107b22e",
+        "rev": "053554b898b3e1d5a3517d0596ed958d2be7b105",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780666,
-        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
@@ -295,11 +295,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778393439,
-        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
+        "lastModified": 1778999127,
+        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
+        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
         "type": "github"
       },
       "original": {
@@ -330,11 +330,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -346,11 +346,11 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1778794387,
-        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -393,11 +393,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -474,10 +474,10 @@
         "sops-nix": "sops-nix"
       },
       "locked": {
-        "lastModified": 1778838172,
-        "narHash": "sha256-bM28S4BCLd7lEE3xNxKKd7oAwhVhqA7t0RRXl07WoGs=",
+        "lastModified": 1779264620,
+        "narHash": "sha256-jLgF4i9kfqvPqPCB5DvJo0ddPBBan3RUv5tx6vk+Ryw=",
         "ref": "main",
-        "rev": "77fbec34a7bf3834fcbed1cf8150f855a0eb8a93",
+        "rev": "35480f8af4cabec0aa9810153da0e4df36893598",
         "shallow": true,
         "type": "git",
         "url": "ssh://git@github.com/aytordev/secrets.git"
@@ -621,11 +621,11 @@
     "yazi-flavors": {
       "flake": false,
       "locked": {
-        "lastModified": 1775725639,
-        "narHash": "sha256-Gm6ThktOLUR+KDs6f3s1WCgrw2TOKQ4tolVvVdCxnCM=",
+        "lastModified": 1778937272,
+        "narHash": "sha256-46x4K4dx4rlU108SXhctJOeGlO/W57Pnofb914Sa4vA=",
         "owner": "yazi-rs",
         "repo": "flavors",
-        "rev": "06708015bfb53b169d99bb3907829f9175105d57",
+        "rev": "54ab389e4deb3d1bc1d8de18d99e825962a55da1",
         "type": "github"
       },
       "original": {

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -29,6 +29,37 @@
         "type": "github"
       }
     },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "import-tree": "import-tree",
+        "nixpkgs": [
+          "root",
+          "meridian",
+          "nixpkgs"
+        ],
+        "systems": [
+          "root",
+          "meridian",
+          "systems"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1770895533,
+        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "2.0.8",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -81,6 +112,24 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
@@ -154,6 +203,21 @@
         "type": "github"
       }
     },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "mcp-servers-nix": {
       "inputs": {
         "nixpkgs": [
@@ -162,16 +226,39 @@
         ]
       },
       "locked": {
-        "lastModified": 1778810872,
-        "narHash": "sha256-mmYGeJPaKHoBmf1jjDKAduMEVsi3WvTdX0jCtbANcw4=",
+        "lastModified": 1779201614,
+        "narHash": "sha256-AFcjCGsu40BwdxjFicL4X6i56XrmACAQW9xPUNU9r4Y=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "4954461ef00c209f60ce911ec4b731ed7107b22e",
+        "rev": "053554b898b3e1d5a3517d0596ed958d2be7b105",
         "type": "github"
       },
       "original": {
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
+        "type": "github"
+      }
+    },
+    "meridian": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "nixpkgs": [
+          "root",
+          "nixpkgs"
+        ],
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1778524794,
+        "narHash": "sha256-rr9l+TGqppjpdQih2/nZ46EexkV2UQ1bMUKnNVu2dWg=",
+        "owner": "rynfar",
+        "repo": "meridian",
+        "rev": "597a3042cbb7435297cab9960c3dccade3e6bd6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian",
         "type": "github"
       }
     },
@@ -222,11 +309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778393439,
-        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
+        "lastModified": 1778999127,
+        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
+        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
         "type": "github"
       },
       "original": {
@@ -237,11 +324,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -251,13 +338,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -306,7 +408,7 @@
           "nixpkgs-unstable"
         ],
         "root": "root_2",
-        "treefmt-nix": "treefmt-nix_2"
+        "treefmt-nix": "treefmt-nix_3"
       }
     },
     "root_2": {
@@ -315,6 +417,7 @@
         "flake-parts": "flake-parts_2",
         "home-manager": [],
         "mcp-servers-nix": "mcp-servers-nix",
+        "meridian": "meridian",
         "nix-darwin": [],
         "nix-index-database": "nix-index-database",
         "nix-rosetta-builder": [],
@@ -366,6 +469,21 @@
         "type": "github"
       }
     },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -389,6 +507,29 @@
       }
     },
     "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "root",
+          "meridian",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -2,9 +2,11 @@
   lib,
   inputs,
   ...
-}: let
+}:
+let
   inherit (lib.aytordev) enabled disabled;
-in {
+in
+{
   aytordev = {
     user = {
       enable = true;
@@ -121,16 +123,25 @@ in {
           # Ollama — M3 Ultra optimized (service managed by darwin launchd module)
           ollama = {
             acceleration = "metal";
-            modelPresets = ["m3-ultra"];
+            modelPresets = [ "m3-ultra" ];
             integrations.zed = true;
           };
 
           # Host-specific SSH configuration
           ssh.knownHosts.github = {
-            hostNames = ["github.com"];
+            hostNames = [ "github.com" ];
             user = "git";
             publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
             identityFile = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
+            identitiesOnly = true;
+            port = 22;
+          };
+
+          # Portfolio Hetzner VPS — update hostNames with the real IP in PR6.T3
+          ssh.knownHosts.hetzner-portfolio = {
+            hostNames = [ "hetzner-portfolio-vps" ]; # TODO PR6.T3: replace with actual VPS IP
+            user = "deploy";
+            identityFile = "/Users/${inputs.secrets.username}/.ssh/portfolio_hetzner_ed25519";
             identitiesOnly = true;
             port = 22;
           };

--- a/modules/home/programs/terminal/tools/ssh/default.nix
+++ b/modules/home/programs/terminal/tools/ssh/default.nix
@@ -3,10 +3,12 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   inherit (lib) mkEnableOption mkOption types;
   cfg = config.aytordev.programs.terminal.tools.ssh;
-in {
+in
+{
   options.aytordev.programs.terminal.tools.ssh = {
     enable = mkEnableOption "SSH configuration";
     port = mkOption {
@@ -16,44 +18,46 @@ in {
     };
     authorizedKeys = mkOption {
       type = types.listOf types.str;
-      default = [];
+      default = [ ];
       description = "List of authorized public keys added to ~/.ssh/authorized_keys";
     };
     knownHosts = mkOption {
-      type = types.attrsOf (types.submodule {
-        options = {
-          hostNames = mkOption {
-            type = types.listOf types.str;
-            description = "List of host names for this known host entry";
+      type = types.attrsOf (
+        types.submodule {
+          options = {
+            hostNames = mkOption {
+              type = types.listOf types.str;
+              description = "List of host names for this known host entry";
+            };
+            user = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "Username to use when connecting to this host";
+            };
+            publicKey = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "Public key for the host (for verification)";
+            };
+            port = mkOption {
+              type = types.nullOr types.port;
+              default = null;
+              description = "Port to use when connecting to this host";
+            };
+            identityFile = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "Path to the private key to use for this host";
+            };
+            identitiesOnly = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              description = "Whether to use only the specified identity file";
+            };
           };
-          user = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            description = "Username to use when connecting to this host";
-          };
-          publicKey = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            description = "Public key for the host (for verification)";
-          };
-          port = mkOption {
-            type = types.nullOr types.port;
-            default = null;
-            description = "Port to use when connecting to this host";
-          };
-          identityFile = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            description = "Path to the private key to use for this host";
-          };
-          identitiesOnly = mkOption {
-            type = types.nullOr types.bool;
-            default = null;
-            description = "Whether to use only the specified identity file";
-          };
-        };
-      });
-      default = {};
+        }
+      );
+      default = { };
       description = "Known hosts configuration with per-host settings";
     };
     extraConfig = mkOption {
@@ -61,10 +65,10 @@ in {
       default = "";
       description = "Additional SSH configuration";
     };
-    matchBlocks = mkOption {
+    extraSettings = mkOption {
       type = types.attrsOf types.attrs;
-      default = {};
-      description = "SSH match blocks for specific hosts";
+      default = { };
+      description = "Additional SSH settings blocks using upstream OpenSSH directive names";
     };
   };
   config = lib.mkIf cfg.enable {
@@ -80,52 +84,49 @@ in {
         TCPKeepAlive = "yes";
       };
       inherit (cfg) extraConfig;
-      matchBlocks = lib.mkMerge [
+      settings = lib.mkMerge [
         {
           "*" = {
-            forwardAgent = false;
-            compression = false;
-            serverAliveInterval = 15;
-            serverAliveCountMax = 3;
-            hashKnownHosts = false;
-            controlMaster = "auto";
-            controlPath = "~/.ssh/controlmasters/%r@%h:%p";
-            controlPersist = "10m";
+            ForwardAgent = false;
+            Compression = false;
+            ServerAliveInterval = 15;
+            ServerAliveCountMax = 3;
+            HashKnownHosts = false;
+            ControlMaster = "auto";
+            ControlPath = "~/.ssh/controlmasters/%r@%h:%p";
+            ControlPersist = "10m";
           };
           "*.local" = {
-            user = config.home.username;
-            inherit (cfg) port;
-            extraOptions = {
-              StrictHostKeyChecking = "no";
-              UserKnownHostsFile = "/dev/null";
-            };
+            User = config.home.username;
+            Port = cfg.port;
+            StrictHostKeyChecking = "no";
+            UserKnownHostsFile = "/dev/null";
           };
         }
         (lib.mapAttrs' (_name: host: {
-            name = lib.concatStringsSep " " host.hostNames;
-            value = {
-              user = host.user or null;
-              port = host.port or null;
-              identityFile = host.identityFile or null;
-              identitiesOnly = host.identitiesOnly or null;
-              extraOptions =
-                lib.optionalAttrs (host ? publicKey) {
-                  HostKeyAlias = lib.head host.hostNames;
-                }
-                // (host.extraOptions or {});
-            };
-          })
-          cfg.knownHosts)
-        cfg.matchBlocks
+          name = lib.concatStringsSep " " host.hostNames;
+          value =
+            lib.filterAttrs (_: v: v != null) {
+              User = host.user or null;
+              Port = host.port or null;
+              IdentityFile = host.identityFile or null;
+              IdentitiesOnly = host.identitiesOnly or null;
+            }
+            // lib.optionalAttrs (host ? publicKey) {
+              HostKeyAlias = lib.head host.hostNames;
+            }
+            // (host.extraOptions or { });
+        }) cfg.knownHosts)
+        cfg.extraSettings
       ];
     };
     home = {
       file = lib.mkMerge [
-        (lib.optionalAttrs (cfg.authorizedKeys != []) {
+        (lib.optionalAttrs (cfg.authorizedKeys != [ ]) {
           ".ssh/authorized_keys".text = lib.concatStringsSep "\n" cfg.authorizedKeys;
         })
       ];
-      activation.createSshControlmastersDir = lib.hm.dag.entryAfter ["writeBoundary"] ''
+      activation.createSshControlmastersDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
         mkdir -p ~/.ssh/controlmasters
         chmod 700 ~/.ssh/controlmasters
       '';

--- a/systems/aarch64-darwin/wang-lin/default.nix
+++ b/systems/aarch64-darwin/wang-lin/default.nix
@@ -3,13 +3,15 @@
   inputs,
   config,
   ...
-}: let
+}:
+let
   inherit (lib.aytordev) enabled;
 
   cfg = config.aytordev.user;
 
   sopsFolder = builtins.toString inputs.secrets + "/hard-secrets";
-in {
+in
+{
   # Host-specific settings only
   # All modules auto-discovered from modules/darwin/
   # All homes auto-injected from homes/aarch64-darwin/aytordev@wang-lin/
@@ -54,6 +56,13 @@ in {
           github_cli_personal_access_token = {
             key = "github_cli_personal_access_token";
             path = "/Users/${inputs.secrets.username}/.config/sops/github_cli_personal_access_token";
+            mode = "0600";
+            owner = inputs.secrets.username;
+          };
+          hetzner_ssh_private_key = {
+            sopsFile = "${sopsFolder}/portfolio.yaml";
+            key = "hetzner_ssh_private_key";
+            path = "/Users/${inputs.secrets.username}/.ssh/portfolio_hetzner_ed25519";
             mode = "0600";
             owner = inputs.secrets.username;
           };


### PR DESCRIPTION
## Summary

Adds SSH configuration for the Hetzner portfolio VPS and refactors the SSH module to use idiomatic OpenSSH directive naming.

## Changes

### refactor(ssh): migrate matchBlocks to extraSettings with PascalCase directives
- Rename `matchBlocks` option to `extraSettings` to better reflect semantics
- Switch all camelCase SSH directive keys to PascalCase (OpenSSH standard)
- Apply nix fmt style: expanded let/in blocks, spaced list brackets
- Filter null attrs instead of passing them through

### feat(ssh): add Hetzner portfolio VPS known host and sops secret
- Add `ssh.knownHosts.hetzner-portfolio` entry (deploy user, port 22)
- Wire sops secret `hetzner_ssh_private_key` from `portfolio.yaml`
- Key written to `~/.ssh/portfolio_hetzner_ed25519` with mode 0600
- hostNames placeholder: update with real VPS IP in PR6.T3

### chore: update flake locks

## Notes

- No linked issue (skipped per user request)
- hostNames for hetzner-portfolio uses a placeholder — update with real IP in follow-up