### PR TITLE
feat(hcloud+rclone): add hcloud and rclone home manager modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,10 +474,10 @@
         "sops-nix": "sops-nix"
       },
       "locked": {
-        "lastModified": 1779264620,
-        "narHash": "sha256-jLgF4i9kfqvPqPCB5DvJo0ddPBBan3RUv5tx6vk+Ryw=",
+        "lastModified": 1779283105,
+        "narHash": "sha256-V4iiW+4iXjznZf2UxNFhgv0UiHJBzuiy0vy4tzzJun4=",
         "ref": "main",
-        "rev": "35480f8af4cabec0aa9810153da0e4df36893598",
+        "rev": "fa48caf49c4ce906dfa837df7b78637ac628c320",
         "shallow": true,
         "type": "git",
         "url": "ssh://git@github.com/aytordev/secrets.git"

--- a/homes/aarch64-darwin/aytordev@wang-lin/default.nix
+++ b/homes/aarch64-darwin/aytordev@wang-lin/default.nix
@@ -2,11 +2,9 @@
   lib,
   inputs,
   ...
-}:
-let
+}: let
   inherit (lib.aytordev) enabled disabled;
-in
-{
+in {
   aytordev = {
     user = {
       enable = true;
@@ -95,6 +93,20 @@ in
           # Host-specific gh authentication via sops
           gh.auth.tokenPath = "/Users/${inputs.secrets.username}/.config/sops/github_cli_personal_access_token";
 
+          # Host-specific hcloud authentication via sops
+          hcloud.auth.tokenPath = "/Users/${inputs.secrets.username}/.config/sops/hcloud_token";
+
+          # Portfolio Backblaze B2 backup remote — secrets injected from sops at activation
+          rclone.remotes.portfolio-b2 = {
+            config = {
+              type = "b2";
+            };
+            secrets = {
+              account = "/Users/${inputs.secrets.username}/.config/sops/b2_key_id";
+              key = "/Users/${inputs.secrets.username}/.config/sops/b2_app_key";
+            };
+          };
+
           # Host-specific git signing key
           git.signingKey = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
 
@@ -123,13 +135,13 @@ in
           # Ollama — M3 Ultra optimized (service managed by darwin launchd module)
           ollama = {
             acceleration = "metal";
-            modelPresets = [ "m3-ultra" ];
+            modelPresets = ["m3-ultra"];
             integrations.zed = true;
           };
 
           # Host-specific SSH configuration
           ssh.knownHosts.github = {
-            hostNames = [ "github.com" ];
+            hostNames = ["github.com"];
             user = "git";
             publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsKijb0PXKfsAmPu0t0jIsiYqfvhyiwPdrWWIwCSzpJ";
             identityFile = "/Users/${inputs.secrets.username}/.ssh/ssh_key_github_ed25519";
@@ -139,7 +151,7 @@ in
 
           # Portfolio Hetzner VPS — update hostNames with the real IP in PR6.T3
           ssh.knownHosts.hetzner-portfolio = {
-            hostNames = [ "hetzner-portfolio-vps" ]; # TODO PR6.T3: replace with actual VPS IP
+            hostNames = ["hetzner-portfolio-vps"]; # TODO PR6.T3: replace with actual VPS IP
             user = "deploy";
             identityFile = "/Users/${inputs.secrets.username}/.ssh/portfolio_hetzner_ed25519";
             identitiesOnly = true;

--- a/modules/home/programs/terminal/tools/hcloud/default.nix
+++ b/modules/home/programs/terminal/tools/hcloud/default.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    ;
+  cfg = config.aytordev.programs.terminal.tools.hcloud;
+  hasToken = cfg.auth.tokenPath != null;
+in
+{
+  options.aytordev.programs.terminal.tools.hcloud = {
+    enable = mkEnableOption "Hetzner Cloud CLI";
+
+    auth = {
+      tokenPath = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "/Users/username/.config/sops/hcloud_token";
+        description = ''
+          Path to a file containing the Hetzner Cloud API token.
+          When set, HCLOUD_TOKEN is exported at shell startup for automatic authentication.
+          Designed to work with sops-nix managed secrets.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.hcloud ];
+
+    programs = {
+      zsh.initContent = mkIf hasToken ''
+        if [[ -f "${cfg.auth.tokenPath}" ]]; then
+          export HCLOUD_TOKEN="$(command cat "${cfg.auth.tokenPath}")"
+        fi
+      '';
+
+      bash.initExtra = mkIf hasToken ''
+        if [[ -f "${cfg.auth.tokenPath}" ]]; then
+          export HCLOUD_TOKEN="$(command cat "${cfg.auth.tokenPath}")"
+        fi
+      '';
+
+      fish.interactiveShellInit = mkIf hasToken ''
+        if test -f "${cfg.auth.tokenPath}"
+          set -gx HCLOUD_TOKEN (command cat "${cfg.auth.tokenPath}")
+        end
+      '';
+
+      nushell.extraEnv = mkIf hasToken ''
+        if ("${cfg.auth.tokenPath}" | path exists) {
+          $env.HCLOUD_TOKEN = (open "${cfg.auth.tokenPath}" | str trim)
+        }
+      '';
+    };
+  };
+}

--- a/modules/home/programs/terminal/tools/rclone/default.nix
+++ b/modules/home/programs/terminal/tools/rclone/default.nix
@@ -1,0 +1,47 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit
+    (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    ;
+  cfg = config.aytordev.programs.terminal.tools.rclone;
+in {
+  options.aytordev.programs.terminal.tools.rclone = {
+    enable = mkEnableOption "rclone";
+
+    remotes = mkOption {
+      type = types.attrsOf types.anything;
+      default = {};
+      example = lib.literalExpression ''
+        {
+          portfolio-b2 = {
+            config = {type = "b2";};
+            secrets = {
+              account = "/path/to/b2_key_id";
+              key = "/path/to/b2_app_key";
+            };
+          };
+        }
+      '';
+      description = ''
+        Rclone remote configurations. Passed through to home-manager's
+        programs.rclone.remotes. See <https://rclone.org/docs/>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.rclone = {
+      enable = true;
+      package = pkgs.rclone;
+      inherit (cfg) remotes;
+    };
+  };
+}

--- a/modules/home/suites/common/default.nix
+++ b/modules/home/suites/common/default.nix
@@ -102,6 +102,7 @@ in {
             navi = mkDefault enabled;
             nix-search-tv = mkDefault enabled;
             nh = mkDefault enabled;
+            rclone = mkDefault enabled;
             ripgrep = mkDefault enabled;
             run-as-service = mkDefault (
               if pkgs.stdenv.hostPlatform.isLinux

--- a/modules/home/suites/development/default.nix
+++ b/modules/home/suites/development/default.nix
@@ -1,10 +1,11 @@
 {
   config,
   lib,
-  osConfig ? {},
+  osConfig ? { },
   pkgs,
   ...
-}: let
+}:
+let
   inherit (lib) mkIf mkDefault;
   inherit (lib.aytordev) enabled;
 
@@ -52,15 +53,14 @@
     yazi-update-all = "./pkgs/by-name/ya/yazi/plugins/update.py --all --commit";
     # Home-Manager
     hmd = "nix build -L .#docs-html; ${
-      if pkgs.stdenv.hostPlatform.isDarwin
-      then "open"
-      else "xdg-open"
+      if pkgs.stdenv.hostPlatform.isDarwin then "open" else "xdg-open"
     } result/share/doc/home-manager/index.xhtml";
     hmt = ''f(){ nix-build -j auto --show-trace --pure --option allow-import-from-derivation false tests -A build."$1"; }; f'';
     hmtf = ''f(){ nix build -L --option allow-import-from-derivation false --reference-lock-file flake.lock "./tests#test-$1"; }; f'';
     hmts = ''f(){ nix build -L --option allow-import-from-derivation false --reference-lock-file flake.lock "./tests#test-$1"; nix path-info -rSh ./result; }; f'';
   };
-in {
+in
+{
   options.aytordev.suites.development = {
     enable = lib.mkEnableOption "common development configuration";
     azureEnable = lib.mkEnableOption "azure development configuration";
@@ -76,7 +76,8 @@ in {
 
   config = mkIf cfg.enable {
     home = {
-      packages = with pkgs;
+      packages =
+        with pkgs;
         [
           jqp
           onefetch
@@ -167,6 +168,8 @@ in {
             git-crypt = mkDefault enabled;
             # go.enable = cfg.goEnable;  # TODO: module doesn't exist
             gh = mkDefault enabled;
+            hcloud = mkDefault enabled;
+            rclone = mkDefault enabled;
             jujutsu = mkDefault enabled;
             jjui = mkDefault enabled;
             k9s.enable = mkDefault cfg.kubernetesEnable;

--- a/systems/aarch64-darwin/wang-lin/default.nix
+++ b/systems/aarch64-darwin/wang-lin/default.nix
@@ -3,15 +3,13 @@
   inputs,
   config,
   ...
-}:
-let
+}: let
   inherit (lib.aytordev) enabled;
 
   cfg = config.aytordev.user;
 
   sopsFolder = builtins.toString inputs.secrets + "/hard-secrets";
-in
-{
+in {
   # Host-specific settings only
   # All modules auto-discovered from modules/darwin/
   # All homes auto-injected from homes/aarch64-darwin/aytordev@wang-lin/
@@ -63,6 +61,27 @@ in
             sopsFile = "${sopsFolder}/portfolio.yaml";
             key = "hetzner_ssh_private_key";
             path = "/Users/${inputs.secrets.username}/.ssh/portfolio_hetzner_ed25519";
+            mode = "0600";
+            owner = inputs.secrets.username;
+          };
+          hetzner_api_token = {
+            sopsFile = "${sopsFolder}/portfolio.yaml";
+            key = "hetzner_api_token";
+            path = "/Users/${inputs.secrets.username}/.config/sops/hcloud_token";
+            mode = "0600";
+            owner = inputs.secrets.username;
+          };
+          b2_key_id = {
+            sopsFile = "${sopsFolder}/portfolio.yaml";
+            key = "b2_key_id";
+            path = "/Users/${inputs.secrets.username}/.config/sops/b2_key_id";
+            mode = "0600";
+            owner = inputs.secrets.username;
+          };
+          b2_app_key = {
+            sopsFile = "${sopsFolder}/portfolio.yaml";
+            key = "b2_app_key";
+            path = "/Users/${inputs.secrets.username}/.config/sops/b2_app_key";
             mode = "0600";
             owner = inputs.secrets.username;
           };


### PR DESCRIPTION
## Summary

Adds home-manager modules for the Hetzner Cloud CLI (`hcloud`) and `rclone`, enables them in the development and common suites, and wires up sops-managed secrets for the `wang-lin` host.

## Changes

- **`feat(hcloud)`**: New module at `modules/home/programs/terminal/tools/hcloud/` — installs the CLI and exports `HCLOUD_TOKEN` at shell startup from a configurable sops-managed path (zsh, bash, fish, nushell)
- **`feat(rclone)`**: New module at `modules/home/programs/terminal/tools/rclone/` — wraps `programs.rclone` with aytordev-namespaced options and declarative remote configuration
- **`feat(suites)`**: Enables `rclone` in the common suite and both `hcloud` + `rclone` in the development suite
- **`feat(wang-lin)`**: Wires `hcloud.auth.tokenPath` and `rclone.remotes.portfolio-b2` to sops secrets (`hetzner_api_token`, `b2_key_id`, `b2_app_key`) from `portfolio.yaml`; bumps `flake.lock` secrets input

## Commits

- `feat(hcloud): add hcloud CLI home manager module`
- `feat(rclone): add rclone home manager module`
- `feat(suites): enable hcloud and rclone in development and common suites`
- `feat(wang-lin): configure hcloud and rclone with sops secrets`