### PR TITLE
feat(dev): add pencil cask and upgrade SDD models

### DIFF
--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -1,6 +1,6 @@
 # Skill Registry — system
 
-Generated: 2026-04-02
+Generated: 2026-05-28
 Project: aytordev/system (NixOS/nix-darwin dotfiles)
 Skill root: ~/.claude/skills/
 
@@ -12,10 +12,25 @@ Skill root: ~/.claude/skills/
 |-------|---------|------|
 | `nix` | When writing or editing Nix expressions, modules, flakes, overlays, or options | `~/.claude/skills/nix/SKILL.md` |
 | `dotfiles-coder` | When modifying modules/, homes/, flake inputs, NixOS/darwin configs, or Home Manager programs | `~/.claude/skills/dotfiles-coder/SKILL.md` |
+| `branch-pr` | When creating, opening, or preparing PRs for review | `~/.claude/skills/branch-pr/SKILL.md` |
+| `chained-pr` | When PRs exceed 400 lines, or splitting stacked changes for review | `~/.claude/skills/chained-pr/SKILL.md` |
+| `cognitive-doc-design` | When writing guides, READMEs, RFCs, onboarding, or architecture docs | `~/.claude/skills/cognitive-doc-design/SKILL.md` |
+| `comment-writer` | When writing PR feedback, issue replies, reviews, or GitHub comments | `~/.claude/skills/comment-writer/SKILL.md` |
+| `issue-creation` | When creating GitHub issues, bug reports, or feature requests | `~/.claude/skills/issue-creation/SKILL.md` |
+| `judgment-day` | When performing adversarial code review, quality gate, or final verification before merge | `~/.claude/skills/judgment-day/SKILL.md` |
+| `work-unit-commits` | When planning commits, splitting changes, or preparing for review | `~/.claude/skills/work-unit-commits/SKILL.md` |
 | `skill-creator` | When creating or updating a skill (SKILL.md, rules/, references/) | `~/.claude/skills/skill-creator/SKILL.md` |
 | `skill-registry` | When regenerating or updating the skill registry | `~/.claude/skills/skill-registry/SKILL.md` |
-| `judgment-day` | When performing adversarial code review, quality gate, or final verification before merge | `~/.claude/skills/judgment-day/SKILL.md` |
-| `sdd-onboard` | When onboarding a user through the full SDD cycle | `~/.claude/skills/sdd-onboard/SKILL.md` |
+| `sdd-init` | When initializing SDD context in a project | `~/.claude/skills/sdd-init/SKILL.md` |
+| `sdd-explore` | When exploring ideas or investigating codebase before committing to a change | `~/.claude/skills/sdd-explore/SKILL.md` |
+| `sdd-propose` | When creating a structured change proposal | `~/.claude/skills/sdd-propose/SKILL.md` |
+| `sdd-spec` | When writing specifications with requirements and scenarios | `~/.claude/skills/sdd-spec/SKILL.md` |
+| `sdd-design` | When creating technical design documents for a change | `~/.claude/skills/sdd-design/SKILL.md` |
+| `sdd-tasks` | When breaking a change into an implementation task checklist | `~/.claude/skills/sdd-tasks/SKILL.md` |
+| `sdd-apply` | When implementing tasks from a change | `~/.claude/skills/sdd-apply/SKILL.md` |
+| `sdd-verify` | When validating that implementation matches specs and design | `~/.claude/skills/sdd-verify/SKILL.md` |
+| `sdd-archive` | When archiving a completed change and syncing delta specs | `~/.claude/skills/sdd-archive/SKILL.md` |
+| `sdd-onboard` | When onboarding a user through the full SDD cycle with narration | `~/.claude/skills/sdd-onboard/SKILL.md` |
 
 ---
 
@@ -24,11 +39,12 @@ Skill root: ~/.claude/skills/
 | File | Purpose |
 |------|---------|
 | `AGENTS.md` | Top-level project constitution — architecture, commands, style rules |
-| `modules/common/ai-tools/AGENTS.md` | AI tools domain — agents, commands, skills inventory |
+| `modules/common/AGENTS.md` | Shared cross-platform module conventions |
 | `modules/home/AGENTS.md` | Home Manager module conventions |
 | `modules/darwin/AGENTS.md` | macOS (nix-darwin) module conventions |
-| `modules/common/AGENTS.md` | Shared cross-platform module conventions |
-| `openspec/config.yaml` | SDD project configuration |
+| `checks/AGENTS.md` | Nix check discovery and auto-loader conventions |
+| `flake/AGENTS.md` | Flake outputs organization |
+| `openspec/config.yaml` | SDD project configuration (strict_tdd: false) |
 
 ---
 
@@ -55,25 +71,73 @@ Skill root: ~/.claude/skills/
 - Build check: `nix build .#homeConfigurations.aytordev.activationPackage --dry-run`
 - Full rebuild: `sudo nixos-rebuild switch --flake .#${host}` (NixOS) or `darwin-rebuild switch --flake .#${host}` (macOS)
 
+### `branch-pr` — Pull request creation (trigger: creating or preparing PRs)
+
+- Check for an existing issue before creating a PR; open one if absent
+- PR title follows conventional commit format: `type(scope): description`
+- PR description links to the issue and summarizes what changed and why
+- Include build/test evidence: `nix fmt && nix flake check` output
+- Request review from CODEOWNERS; apply labels per `.github/labeler.yml`
+
+### `chained-pr` — Oversized PR splitting (trigger: PRs >400 lines, stacked changes)
+
+- Split into a base PR (foundation/types) + one or more follow-on PRs
+- Each PR in the chain must be independently reviewable and must not break CI
+- PR description references the parent PR and explains its position in the chain
+- Keep each PR under ~400 lines of substantive change
+- Mark follow-on PRs as draft until the base is merged
+
+### `cognitive-doc-design` — Documentation (trigger: READMEs, guides, architecture docs)
+
+- Lead with the "why" before the "what" — context before detail
+- Use progressive disclosure: overview → details → reference
+- One concept per section; avoid mixing concerns
+- Prefer concrete examples before abstract rules
+- Active voice, present tense; avoid "will", "should", "might"
+
+### `comment-writer` — Collaboration comments (trigger: PR reviews, issue replies)
+
+- Reference specific lines or functions — never vague ("this looks off")
+- Classify: blocking (must fix before merge) vs. non-blocking (suggestion/nit)
+- Propose an alternative when raising a concern — not just the problem
+- Acknowledge what works before listing concerns
+- Use "we" framing for collaborative suggestions, not "you did X wrong"
+
+### `issue-creation` — GitHub issues (trigger: bug reports, feature requests)
+
+- Check for duplicate issues before creating
+- Use the appropriate `.github/ISSUE_TEMPLATE/` template
+- Bugs: include reproduction steps, expected vs. actual, and environment info
+- Features: include acceptance criteria and motivation
+- Apply labels from `.github/labeler.yml`
+
+### `judgment-day` — Adversarial review (trigger: final verification, pre-merge)
+
+- Two blind judges review independently, then synthesize findings
+- Verdict: APPROVED, APPROVED_WITH_CONCERNS, or REJECTED
+- REJECTED requires a specific fix list before re-judging
+- Convergence after 3 rounds — escalate unresolved blockers to user
+
+### `work-unit-commits` — Commit planning (trigger: implementation, commit splitting)
+
+- One logical change per commit — tests, docs, and code together in the same commit
+- Never split a change such that intermediate commits break CI
+- Commit message format: `type(scope): description` (conventional commits)
+- Prefer atomic commits; avoid WIP or checkpoint commits in final history
+- Use `git rebase -i` to clean history before pushing
+
 ### `skill-creator` — Skill format (trigger: skills/ directory, SKILL.md, rules/)
 
 - Every skill needs: `SKILL.md` (index + protocol) + `rules/` (execution steps + constraints)
 - Optional: `references/` (templates), `modules/` (extension modules)
-- SKILL.md frontmatter: `name`, `description`, `license`, `metadata.author`, `metadata.version`
+- SKILL.md frontmatter: `name`, `description`
 - Rule files: kebab-case, named `{category}-{specifics}.md`
-- Compact rules in skill-registry must be actionable in ≤5 bullets
-
-### `judgment-day` — Adversarial review (trigger: final verification, pre-merge)
-
-- Two blind judges review independently, then synthesize
-- Verdict: APPROVED, APPROVED_WITH_CONCERNS, or REJECTED
-- REJECTED requires specific fix list before re-judging
-- Convergence after 3 rounds — escalate blockers to user
+- Compact rules in skill-registry must be actionable in 5-15 bullets
 
 ---
 
 ## Skill Resolution Report
 
-Last resolved: 2026-04-02
-Mode: openspec
-Active change: (none)
+Last resolved: 2026-05-28
+Mode: engram
+Active changes: ai-tools-parity-fix, engram-nix-update, sdd-onboard-and-hybrid-mode

--- a/modules/common/ai-tools/agents/sdd/sdd-orchestrator.nix
+++ b/modules/common/ai-tools/agents/sdd/sdd-orchestrator.nix
@@ -3,14 +3,15 @@ let
   # Change a model here and it propagates automatically to the orchestrator prompt.
   sddModels = {
     haiku = "anthropic/claude-haiku-4-5-20251001";
-    sonnet = "anthropic/claude-sonnet-4-5-20250929";
+    sonnet = "anthropic/claude-sonnet-4-6";
+    opus = "anthropic/claude-opus-4-7";
   };
 
   phaseModels = [
     {
       phase = "sdd-init";
-      model = sddModels.haiku;
-      rationale = "Quick context detection";
+      model = sddModels.sonnet;
+      rationale = "Stack detection + skill registry build (8-step workflow)";
     }
     {
       phase = "sdd-explore";
@@ -29,8 +30,8 @@ let
     }
     {
       phase = "sdd-design";
-      model = sddModels.sonnet;
-      rationale = "Architecture reasoning";
+      model = sddModels.opus;
+      rationale = "Architecture reasoning — judgment-critical, downstream phases depend on design quality";
     }
     {
       phase = "sdd-tasks";
@@ -57,16 +58,21 @@ let
   renderModelRow = entry: "| ${entry.phase} | `${entry.model}` | ${entry.rationale} |";
   modelRouterRows = builtins.concatStringsSep "\n" (builtins.map renderModelRow phaseModels);
 
-  orchestratorContent =
-    builtins.replaceStrings
-    ["@SDD_MODEL_ROUTER_ROWS@"]
-    [modelRouterRows]
-    (builtins.readFile ./sdd-orchestrator.md);
+  orchestratorContent = builtins.replaceStrings ["@SDD_MODEL_ROUTER_ROWS@"] [modelRouterRows] (
+    builtins.readFile ./sdd-orchestrator.md
+  );
 in {
   sdd-orchestrator = {
     name = "sdd-orchestrator";
     description = "SDD Orchestrator - delegates spec-driven development to sub-agents via Task tool";
-    tools = ["Read" "Write" "Edit" "Bash" "Grep" "Glob"];
+    tools = [
+      "Read"
+      "Write"
+      "Edit"
+      "Bash"
+      "Grep"
+      "Glob"
+    ];
     model = {
       claude = "sonnet";
       opencode = sddModels.sonnet;

--- a/modules/darwin/suites/development/default.nix
+++ b/modules/darwin/suites/development/default.nix
@@ -2,10 +2,12 @@
   config,
   lib,
   ...
-}: let
+}:
+let
   inherit (lib) mkIf;
   cfg = config.aytordev.suites.development;
-in {
+in
+{
   options.aytordev.suites.development = {
     enable = lib.mkEnableOption "common development configuration";
     dockerEnable = lib.mkEnableOption "docker desktop configuration";
@@ -18,16 +20,16 @@ in {
     # aytordev.nix.nix-rosetta-builder.enable = true;
 
     homebrew = {
-      casks =
-        [
-          "ghostty"
-        ]
-        ++ lib.optionals cfg.dockerEnable [
-          "docker-desktop"
-        ]
-        ++ lib.optionals cfg.podmanEnable [
-          "podman-desktop"
-        ];
+      casks = [
+        "ghostty"
+        "pencil"
+      ]
+      ++ lib.optionals cfg.dockerEnable [
+        "docker-desktop"
+      ]
+      ++ lib.optionals cfg.podmanEnable [
+        "podman-desktop"
+      ];
 
       masApps = mkIf config.aytordev.tools.homebrew.masEnable {
         # TODO: Add Mac App Store apps

--- a/modules/home/programs/terminal/tools/hcloud/default.nix
+++ b/modules/home/programs/terminal/tools/hcloud/default.nix
@@ -3,9 +3,9 @@
   lib,
   pkgs,
   ...
-}:
-let
-  inherit (lib)
+}: let
+  inherit
+    (lib)
     mkIf
     mkEnableOption
     mkOption
@@ -13,8 +13,7 @@ let
     ;
   cfg = config.aytordev.programs.terminal.tools.hcloud;
   hasToken = cfg.auth.tokenPath != null;
-in
-{
+in {
   options.aytordev.programs.terminal.tools.hcloud = {
     enable = mkEnableOption "Hetzner Cloud CLI";
 
@@ -33,7 +32,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.hcloud ];
+    home.packages = [pkgs.hcloud];
 
     programs = {
       zsh.initContent = mkIf hasToken ''

--- a/modules/home/programs/terminal/tools/ssh/default.nix
+++ b/modules/home/programs/terminal/tools/ssh/default.nix
@@ -3,12 +3,10 @@
   lib,
   pkgs,
   ...
-}:
-let
+}: let
   inherit (lib) mkEnableOption mkOption types;
   cfg = config.aytordev.programs.terminal.tools.ssh;
-in
-{
+in {
   options.aytordev.programs.terminal.tools.ssh = {
     enable = mkEnableOption "SSH configuration";
     port = mkOption {
@@ -18,7 +16,7 @@ in
     };
     authorizedKeys = mkOption {
       type = types.listOf types.str;
-      default = [ ];
+      default = [];
       description = "List of authorized public keys added to ~/.ssh/authorized_keys";
     };
     knownHosts = mkOption {
@@ -57,7 +55,7 @@ in
           };
         }
       );
-      default = { };
+      default = {};
       description = "Known hosts configuration with per-host settings";
     };
     extraConfig = mkOption {
@@ -67,7 +65,7 @@ in
     };
     extraSettings = mkOption {
       type = types.attrsOf types.attrs;
-      default = { };
+      default = {};
       description = "Additional SSH settings blocks using upstream OpenSSH directive names";
     };
   };
@@ -104,29 +102,30 @@ in
           };
         }
         (lib.mapAttrs' (_name: host: {
-          name = lib.concatStringsSep " " host.hostNames;
-          value =
-            lib.filterAttrs (_: v: v != null) {
-              User = host.user or null;
-              Port = host.port or null;
-              IdentityFile = host.identityFile or null;
-              IdentitiesOnly = host.identitiesOnly or null;
-            }
-            // lib.optionalAttrs (host ? publicKey) {
-              HostKeyAlias = lib.head host.hostNames;
-            }
-            // (host.extraOptions or { });
-        }) cfg.knownHosts)
+            name = lib.concatStringsSep " " host.hostNames;
+            value =
+              lib.filterAttrs (_: v: v != null) {
+                User = host.user or null;
+                Port = host.port or null;
+                IdentityFile = host.identityFile or null;
+                IdentitiesOnly = host.identitiesOnly or null;
+              }
+              // lib.optionalAttrs (host ? publicKey) {
+                HostKeyAlias = lib.head host.hostNames;
+              }
+              // (host.extraOptions or {});
+          })
+          cfg.knownHosts)
         cfg.extraSettings
       ];
     };
     home = {
       file = lib.mkMerge [
-        (lib.optionalAttrs (cfg.authorizedKeys != [ ]) {
+        (lib.optionalAttrs (cfg.authorizedKeys != []) {
           ".ssh/authorized_keys".text = lib.concatStringsSep "\n" cfg.authorizedKeys;
         })
       ];
-      activation.createSshControlmastersDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      activation.createSshControlmastersDir = lib.hm.dag.entryAfter ["writeBoundary"] ''
         mkdir -p ~/.ssh/controlmasters
         chmod 700 ~/.ssh/controlmasters
       '';

--- a/modules/home/suites/development/default.nix
+++ b/modules/home/suites/development/default.nix
@@ -1,11 +1,10 @@
 {
   config,
   lib,
-  osConfig ? { },
+  osConfig ? {},
   pkgs,
   ...
-}:
-let
+}: let
   inherit (lib) mkIf mkDefault;
   inherit (lib.aytordev) enabled;
 
@@ -53,14 +52,15 @@ let
     yazi-update-all = "./pkgs/by-name/ya/yazi/plugins/update.py --all --commit";
     # Home-Manager
     hmd = "nix build -L .#docs-html; ${
-      if pkgs.stdenv.hostPlatform.isDarwin then "open" else "xdg-open"
+      if pkgs.stdenv.hostPlatform.isDarwin
+      then "open"
+      else "xdg-open"
     } result/share/doc/home-manager/index.xhtml";
     hmt = ''f(){ nix-build -j auto --show-trace --pure --option allow-import-from-derivation false tests -A build."$1"; }; f'';
     hmtf = ''f(){ nix build -L --option allow-import-from-derivation false --reference-lock-file flake.lock "./tests#test-$1"; }; f'';
     hmts = ''f(){ nix build -L --option allow-import-from-derivation false --reference-lock-file flake.lock "./tests#test-$1"; nix path-info -rSh ./result; }; f'';
   };
-in
-{
+in {
   options.aytordev.suites.development = {
     enable = lib.mkEnableOption "common development configuration";
     azureEnable = lib.mkEnableOption "azure development configuration";
@@ -76,8 +76,7 @@ in
 
   config = mkIf cfg.enable {
     home = {
-      packages =
-        with pkgs;
+      packages = with pkgs;
         [
           jqp
           onefetch

--- a/openspec/changes/engram-nix-update/exploration.md
+++ b/openspec/changes/engram-nix-update/exploration.md
@@ -1,0 +1,209 @@
+# Exploration: engram-nix-update
+
+**Change:** engram-nix-update
+**Date:** 2026-05-20
+**Status:** complete
+
+---
+
+## Executive Summary
+
+Engram is already fully integrated into this dotfiles repo as a custom
+`buildGoModule` derivation in `packages/engram/package.nix`, exposed as
+`pkgs.aytordev.engram` via the auto-discovery overlay, wired as an MCP server,
+and enabled by the development suite when `aiEnable = true`. The sole problem is
+version drift: the repo is pinned to `v1.7.0` while upstream has released
+`v1.15.15` (8 minor versions ahead). There is no automated update mechanism —
+updates require manually editing `version`, `hash`, and `vendorHash` in the
+derivation file. The recommended path is a version bump to `v1.15.15` combined
+with adding a `just update-engram` Justfile target powered by `nix-update` to
+prevent future drift.
+
+---
+
+## Detailed Report
+
+### 1. Existing Engram References
+
+| File | Role |
+|------|------|
+| `packages/engram/package.nix` | Custom `buildGoModule` derivation, pinned to `v1.7.0` |
+| `modules/home/programs/terminal/tools/engram/default.nix` | HM module under `aytordev.programs.terminal.tools.engram`, installs `pkgs.aytordev.engram` |
+| `modules/home/programs/terminal/tools/mcp/default.nix` | Wires engram as MCP server (`command = getExe pkgs.aytordev.engram`, `args = ["mcp"]`, `ENGRAM_DATA_DIR` env var) |
+| `modules/home/suites/development/default.nix:161` | `engram.enable = mkDefault cfg.aiEnable` — enabled as part of AI tool suite |
+| `flake.nix` | No engram flake input — source fetched inline via `fetchFromGitHub` |
+| `flake.lock` | No engram entry — not tracked in lock file |
+
+The integration is complete and idiomatic. No missing wiring; the only issue is
+the stale version.
+
+### 2. How Other MCP Servers and AI Tools Are Packaged
+
+Three distinct patterns exist in this repo:
+
+**Pattern A — nixpkgs direct** (`pkgs.mcp-nixos`):
+Used when the package exists in nixpkgs. Zero maintenance overhead.
+
+**Pattern B — flake input packages** (`inputs.mcp-servers-nix.packages.${system}`):
+Used for `mcp-server-filesystem`. The `mcp-servers-nix` flake provides
+pre-packaged MCP servers. Updates via `nix flake update mcp-servers-nix`.
+
+**Pattern C — custom `packages/` derivation** (`pkgs.aytordev.*`):
+Used for `engram`, `agentapi`, `meridian-plugin-opencode-scrub`. Applied when the
+tool is not in nixpkgs or any tracked flake. Auto-discovered by
+`lib.filesystem.packagesFromDirectoryRecursive` in `flake/packages/default.nix`.
+Exposed as `pkgs.aytordev.{name}`. Updates are fully manual.
+
+Engram correctly falls into Pattern C. All Pattern C packages pin a version with
+hardcoded hashes — this is the established convention.
+
+### 3. Nix Packaging Options for Engram
+
+| Option | Feasibility | Notes |
+|--------|-------------|-------|
+| Custom `buildGoModule` (current) | Already done | Standard Go binary, works perfectly |
+| nixpkgs package | Not available | Engram is not in nixpkgs as of 2026-05-20 |
+| Flake input (`flake = false`) | Possible | Tracks source in `flake.lock`; `vendorHash` still manual |
+| Upstream flake input | Unknown | Need to verify if upstream has `flake.nix` |
+| npm2nix / node2nix | Not applicable | Engram is a Go binary, not Node.js |
+
+The current `buildGoModule` approach is the correct and complete solution.
+No re-packaging needed.
+
+### 4. Current Update Mechanism and Limitations
+
+**Mechanism:** Fully manual. To update engram:
+1. Edit `version` string in `packages/engram/package.nix`
+2. Update `hash` (source hash via `nix-prefetch-github` or `nix build`)
+3. Update `vendorHash` (Go vendor hash — only changes when `go.mod`/`go.sum` change)
+
+**Limitations:**
+- No automation — no `nix flake update` command available (engram is not a flake input)
+- Easy to fall behind: currently `v1.7.0` vs upstream `v1.15.15` (8 minor releases)
+- Hash recomputation requires trial-and-error or separate tooling
+- No CI check for upstream version drift
+
+### 5. Approaches Compared
+
+#### Approach A — Manual version bump (keep current pattern)
+
+Update `version`, `hash`, and `vendorHash` in `packages/engram/package.nix`.
+
+**Pros:**
+- Zero structural change to the repo
+- Perfectly consistent with `agentapi`, `meridian-plugin-opencode-scrub`
+- `nix build .#engram` and all downstream consumers work unchanged
+- Reproducible and hermetic
+
+**Cons:**
+- Fully manual — relies on developer remembering to update
+- Hash recomputation friction (requires `nix-prefetch` or failed build)
+- Will drift again without a process change
+
+**Effort:** ~5 minutes per update
+
+---
+
+#### Approach B — Flake input with `flake = false`
+
+Add to `flake.nix`:
+```nix
+engram = {
+  url = "github:Gentleman-Programming/engram/v1.15.15";
+  flake = false;
+};
+```
+Replace `fetchFromGitHub` in `package.nix` with `src = inputs.engram`.
+
+**Pros:**
+- Source version tracked in `flake.lock`
+- `nix flake update engram` bumps the source hash automatically
+- Explicit version pinning visible in lock file
+
+**Cons:**
+- `vendorHash` still requires manual update when Go deps change (the harder part)
+- Adds a flake input for a non-flake source — inconsistent with repo pattern
+- All other custom packages use `fetchurl`/`fetchFromGitHub` — this would be the only exception
+- Version appears in two places (`flake.nix` URL and derivation `version` var)
+
+**Effort:** ~15 minutes to set up; ~2 minutes per update (source only)
+
+---
+
+#### Approach C — `nix-update` + Justfile target (recommended addition)
+
+Keep Approach A's pattern, but add automation via `nix-update`:
+```bash
+# Justfile target
+update-engram:
+    nix-update pkgs.aytordev.engram --version latest
+```
+
+`nix-update` automatically:
+- Fetches the latest GitHub release tag
+- Recomputes `hash` and `vendorHash`
+- Patches `packages/engram/package.nix` in place
+
+**Pros:**
+- One command to fully update engram including vendor hash
+- Consistent with existing `packages/` pattern — zero structural change
+- Automatable in CI/cron if desired
+- `nix-update` is the standard tool for this exact use case in the Nix ecosystem
+
+**Cons:**
+- Requires `nix-update` in the dev shell (`devShells`)
+- Still a manual trigger (unless wired to CI)
+- First-time setup requires adding `nix-update` to dev dependencies
+
+**Effort:** ~10 minutes to set up; ~1 minute per update
+
+---
+
+## Recommended Approach
+
+**Immediate: Approach A** — bump `packages/engram/package.nix` to `v1.15.15`.
+This is the smallest correct change with zero risk and resolves the current drift.
+
+**Structural: Approach C** — add `nix-update` to the dev shell and a `just update-engram`
+Justfile target. This prevents future drift without breaking the repo's established
+`packages/` pattern. Approach B is not recommended because it introduces an
+inconsistency for marginal benefit (`vendorHash` is still manual, and all other
+custom packages use inline fetch).
+
+**Combined scope:**
+1. Update `packages/engram/package.nix`: `version`, `hash`, `vendorHash` → `v1.15.15`
+2. Add `nix-update` to dev shell (check `dev-shells/` structure)
+3. Add `just update-engram` target to `Justfile`
+
+---
+
+## Artifacts
+
+- `packages/engram/package.nix` — derivation to update
+- `modules/home/programs/terminal/tools/engram/default.nix` — HM module (no changes needed)
+- `modules/home/programs/terminal/tools/mcp/default.nix` — MCP wiring (no changes needed)
+- `modules/home/suites/development/default.nix` — suite integration (no changes needed)
+- `flake/packages/default.nix` — auto-discovery mechanism (no changes needed)
+- `Justfile` — add update target
+- `dev-shells/` — add `nix-update` dependency
+
+---
+
+## Risks
+
+| Risk | Severity | Notes |
+|------|----------|-------|
+| `vendorHash` changed between `v1.7.0` and `v1.15.15` | Likely | Go deps almost certainly changed over 8 minor versions; will need correct `vendorHash` |
+| Breaking API changes in engram `v1.15.x` | Low | MCP server interface is stable; `args = ["mcp"]` pattern unlikely to change |
+| `nix-update` not finding package path | Low | May need `--attr pkgs.aytordev.engram` flag tuning |
+
+---
+
+## Next Recommended Phase
+
+**`sdd-propose`** — the scope is clear and bounded. Proposal should cover:
+- Version bump to `v1.15.15`
+- `nix-update` dev shell integration
+- Justfile update target
+
+No design phase needed (trivial change). Can go directly to `sdd-tasks` after proposal.

--- a/openspec/changes/engram-nix-update/proposal.md
+++ b/openspec/changes/engram-nix-update/proposal.md
@@ -1,0 +1,75 @@
+# Proposal: engram-nix-update
+
+**Date:** 2026-05-20
+**Status:** draft
+
+---
+
+## Intent
+
+Bump the engram MCP server from v1.7.0 to v1.15.15 (8 minor versions of drift) and add `nix-update` tooling so future version bumps require a single command instead of manual hash recomputation.
+
+## Scope
+
+### In Scope
+- Update `version`, `hash`, and `vendorHash` in `packages/engram/package.nix` to v1.15.15
+- Add `nix-update` to the dev shell (`dev-shells/`)
+- Add `just update-engram` target to `Justfile`
+
+### Out of Scope
+- `modules/home/programs/terminal/tools/engram/default.nix` — HM module unchanged
+- `modules/home/programs/terminal/tools/mcp/default.nix` — MCP wiring unchanged
+- `modules/home/suites/development/default.nix` — suite integration unchanged
+- `flake.nix` / `flake.lock` — engram stays as inline `fetchFromGitHub` (no flake input)
+- Migrating to Approach B (flake input) — rejected; adds inconsistency for marginal benefit
+
+## Capabilities
+
+> This section is the CONTRACT between proposal and specs phases.
+> The sdd-spec agent reads this to know exactly which spec files to create or update.
+
+### New Capabilities
+None — version bump and dev tooling addition with no behavioral changes.
+
+### Modified Capabilities
+None — MCP server interface, HM options, and suite wiring remain unchanged.
+
+## Approach
+
+Apply Approaches A + C from exploration in a single change:
+
+1. **Version bump (A):** Edit `packages/engram/package.nix` — update `version` to `"1.15.15"`, recompute `hash` (source) and `vendorHash` (Go vendor). Use a failed build to surface the correct hashes, or run `just update-engram` once tooling is in place.
+2. **Dev tooling (C):** Add `pkgs.nix-update` to the dev shell. Add `update-engram` Justfile target invoking `nix-update engram --version latest` with the correct flake attribute path.
+
+Approach B (flake input with `flake = false`) rejected: it would be the only non-inline-fetch custom package in the repo, and `vendorHash` still requires manual recomputation — inconsistency for no net gain.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `packages/engram/package.nix` | high | `version`, `hash`, `vendorHash` updated to v1.15.15 |
+| `Justfile` | low | Add `update-engram` target |
+| `dev-shells/` | low | Add `pkgs.nix-update` package |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `vendorHash` changed across 8 minor versions | High | Expected — recompute from failed build output; `nix-update` automates this |
+| Breaking MCP API change in v1.15.x | Low | `args = ["mcp"]` interface is stable; verify `engram mcp` starts after build |
+| `nix-update` attribute path mismatch | Low | Test `nix-update engram --version latest` dry-run; adjust attr flag if needed |
+
+## Rollback Plan
+
+`git revert` or `git checkout HEAD -- packages/engram/package.nix` restores the prior `version`/`hash`/`vendorHash` triple. The Justfile and dev shell additions are inert if not used and carry zero rollback risk. HM module, MCP wiring, and suite require no rollback action.
+
+## Dependencies
+
+- `pkgs.nix-update` — available in nixpkgs; no additional flake input required
+
+## Success Criteria
+
+- [ ] `nix build .#engram` succeeds and produces a v1.15.15 binary
+- [ ] `nix fmt && nix build .#homeConfigurations.aytordev.activationPackage --dry-run` passes
+- [ ] `just update-engram` runs without error inside the dev shell
+- [ ] `engram mcp` starts without error after home activation

--- a/openspec/changes/engram-nix-update/tasks.md
+++ b/openspec/changes/engram-nix-update/tasks.md
@@ -1,0 +1,117 @@
+# Tasks: engram-nix-update
+
+**Change:** engram-nix-update
+**Date:** 2026-05-21
+**Status:** ready
+
+---
+
+## Phase 1: Dev Tooling Setup
+
+Add `nix-update` to the nix dev shell and a Justfile recipe so future version bumps require one command.
+
+### 1.1 — Add `nix-update` to `dev-shells/nix/default.nix`
+
+**File:** `dev-shells/nix/default.nix`
+
+Add `nix-update` to the existing `with pkgs;` packages list alongside `just`:
+
+```nix
+packages = with pkgs; [
+  just
+  nix-update
+];
+```
+
+**Acceptance:** `nix-update` present in the packages list; `nix eval .#devShells.aarch64-darwin.nix` resolves without error.
+
+---
+
+### 1.2 — Add `update-engram` recipe to `Justfile`
+
+**File:** `Justfile`
+
+Insert after the `upp` recipe (after line 22), inside the existing `[group('nix')]` section:
+
+```just
+# Update engram package to latest upstream release
+[group('nix')]
+update-engram:
+    nix-update --flake engram --version latest
+```
+
+**Acceptance:** `just --list` shows `update-engram` in the nix group; file parses without error.
+
+---
+
+## Phase 2: Version Bump
+
+Bump `packages/engram/package.nix` from v1.7.0 to v1.15.15.
+
+### 2.1 — Run `just update-engram` inside the nix dev shell (primary path)
+
+```bash
+nix develop .#nix --command just update-engram
+```
+
+`nix-update` will resolve the latest tag, recompute `hash` and `vendorHash`, and patch `packages/engram/package.nix` in place.
+
+If `nix-update` errors with an attribute-not-found message, try these attribute variations in order and use whichever resolves:
+```bash
+nix-update --flake engram --version latest
+nix-update --flake packages.engram --version latest
+nix-update --flake aytordev.engram --version latest
+```
+
+Update the Justfile recipe (task 1.2) with the working attribute once confirmed.
+
+**Acceptance:** `packages/engram/package.nix` shows `version = "1.15.15"` with updated `hash` and `vendorHash`.
+
+---
+
+### 2.2 — Fallback: manual hash recomputation (if task 2.1 cannot resolve attribute)
+
+**File:** `packages/engram/package.nix`
+
+**Step A — Set new version and invalidate source hash:**
+
+```nix
+version = "1.15.15";
+# in fetchFromGitHub:
+hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+```
+
+Run `nix build .#engram`. Build fails with a hash mismatch. Copy the `got:` value into `hash`.
+
+**Step B — Invalidate vendor hash:**
+
+```nix
+vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+```
+
+Run `nix build .#engram` again. Build fails with a vendor hash mismatch. Copy the `got:` value into `vendorHash`. (If `go.mod`/`go.sum` are unchanged since v1.7.0, the existing `vendorHash` may still be valid — unlikely over 8 minor versions.)
+
+**Acceptance:** `nix build .#engram` exits 0; `./result/bin/engram --version` reports `1.15.15`.
+
+---
+
+## Phase 3: Verification
+
+### 3.1 — Verify engram binary builds and reports correct version
+
+```bash
+nix build .#engram
+./result/bin/engram --version
+```
+
+**Acceptance:** Build exits 0; version output contains `1.15.15`.
+
+---
+
+### 3.2 — Run full home-manager dry-run
+
+```bash
+nix fmt && nix build .#homeConfigurations.aytordev.activationPackage --dry-run
+```
+
+**Acceptance:** Both commands exit 0 with no errors or warnings.


### PR DESCRIPTION
## Summary

- Add `pencil` cask to darwin development suite
- Upgrade SDD orchestrator models: sonnet → sonnet-4-6, add opus-4-7
- Promote `sdd-init` to sonnet and `sdd-design` to opus for better quality
- Apply `nix fmt` formatting to hcloud, ssh, and home dev suite modules
- Update skill registry
- Add engram-nix-update openspec change specs

## Changes

- `modules/darwin/suites/development/default.nix`: add pencil cask
- `modules/common/ai-tools/agents/sdd/sdd-orchestrator.nix`: model upgrades
- `modules/home/programs/terminal/tools/{hcloud,ssh}/default.nix`: formatting
- `modules/home/suites/development/default.nix`: formatting
- `.atl/skill-registry.md`: update skill registry
- `openspec/changes/engram-nix-update/`: add SDD change specs