### PR TITLE
chore(config): update flakes and platform integrations

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -42,7 +42,7 @@ gc:
 # Run tests
 [group('nix')]
 test:
-    nix eval .#evalTests --show-trace --print-build-logs --verbose
+    nix flake check --extra-experimental-features "nix-command flakes" --show-trace --print-build-logs
 
 ############################################################################
 # System Management

--- a/dev-shells/AGENTS.md
+++ b/dev-shells/AGENTS.md
@@ -11,7 +11,7 @@ dev-shells/
 ├── nix/                # Nix development tools
 ├── node-22-lts/        # Node.js 22 LTS
 ├── node-24-lts/        # Node.js 24 LTS
-├── node-25/            # Node.js 25 (Current)
+├── node-26/            # Node.js 26 (Current)
 ├── python/             # Python 3.13 + uv
 ├── react/              # React development
 └── ...
@@ -79,7 +79,7 @@ mkShell {
 - **nix**: Tools for working with Nix code (just runner).
 - **node-22-lts**: Node.js 22 environment.
 - **node-24-lts**: Node.js 24 environment.
-- **node-25**: Node.js 25 environment.
+- **node-26**: Node.js 26 environment.
 - **python**: Python 3.13 with uv package manager.
 - **react**: Frontend development with Node, pnpm, yarn, bun, and TypeScript.
 

--- a/dev-shells/node-26/default.nix
+++ b/dev-shells/node-26/default.nix
@@ -5,7 +5,7 @@
 }: let
   inherit (pkgs) lib;
   nodePackages = with pkgs; [
-    nodejs_25
+    nodejs_26
     yarn
     pnpm
   ];
@@ -14,7 +14,7 @@ in
     packages = nodePackages;
 
     shellHook = ''
-      echo -e "\n\033[1;32m🎯 Node.js 25 Shell\033[0m"
+      echo -e "\n\033[1;32m🎯 Node.js 26 Shell\033[0m"
       echo ""
       echo "📦 Available tools:"
       ${lib.concatMapStringsSep "\n" (

--- a/flake.lock
+++ b/flake.lock
@@ -9,8 +9,10 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nvf": "nvf",
-        "systems": "systems_2",
+        "nvf": [
+          "nvf"
+        ],
+        "systems": "systems",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -29,7 +31,10 @@
     },
     "bun2nix": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
+        "flake-parts": [
+          "meridian",
+          "flake-parts"
+        ],
         "import-tree": "import-tree",
         "nixpkgs": [
           "meridian",
@@ -59,11 +64,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1751685974,
-        "narHash": "sha256-NKw96t+BgHIYzHUjkTK95FqYRVKB8DHpVhefWSz/kTw=",
+        "lastModified": 1777699697,
+        "narHash": "sha256-Eg9b/rq/ECYwNwEXs5i9wHyhxNI0JrYx2srdI2uZMaQ=",
         "ref": "refs/heads/main",
-        "rev": "549f2762aebeff29a2e5ece7a7dc0f955281a1d1",
-        "revCount": 92,
+        "rev": "382052b74656a369c5408822af3f2501e9b1af81",
+        "revCount": 94,
         "type": "git",
         "url": "https://git.lix.systems/lix-project/flake-compat.git"
       },
@@ -75,17 +80,15 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
-          "aytordev-nvim",
-          "nvf",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -97,6 +100,7 @@
     "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": [
+          "meridian",
           "nixpkgs"
         ]
       },
@@ -106,24 +110,6 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_3": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
@@ -160,11 +146,32 @@
         ]
       },
       "locked": {
-        "lastModified": 1779213149,
-        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
+        "lastModified": 1784129366,
+        "narHash": "sha256-N5JiyICSeQF14x+OQebNyPpYowOT9Rs1iKyeCylSzOA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
+        "rev": "165228b0efefc3e635e5174020c40ea64271dc25",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_3": {
+      "inputs": {
+        "nixpkgs": [
+          "meridian",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781642113,
+        "narHash": "sha256-mAR7KTS9rjreTcXCNqfCbN96mnhJO8lDQq1vl7GviBQ=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "df4e0465717a2d34f05b8ccd967275aaf3ceaa01",
         "type": "github"
       },
       "original": {
@@ -195,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779201614,
-        "narHash": "sha256-AFcjCGsu40BwdxjFicL4X6i56XrmACAQW9xPUNU9r4Y=",
+        "lastModified": 1784293699,
+        "narHash": "sha256-NU0hTN14YgxSrTDU0ELAF7i5gjsqHxI9AsbS38nAO/4=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "053554b898b3e1d5a3517d0596ed958d2be7b105",
+        "rev": "9537416185661acf10c59cec4886105f60bf2a7e",
         "type": "github"
       },
       "original": {
@@ -211,60 +218,90 @@
     "meridian": {
       "inputs": {
         "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts_2",
+        "home-manager": "home-manager_3",
+        "meridian-plugin-hermes-scrub": "meridian-plugin-hermes-scrub",
+        "meridian-plugin-opencode-scrub": "meridian-plugin-opencode-scrub",
+        "meridian-plugin-pi-scrub": "meridian-plugin-pi-scrub",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_3"
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1778524794,
-        "narHash": "sha256-rr9l+TGqppjpdQih2/nZ46EexkV2UQ1bMUKnNVu2dWg=",
+        "lastModified": 1784314998,
+        "narHash": "sha256-2zwk40gqJkH1ZvtulzbizJ1zXgyRSGc0cPj3XBqbtYo=",
         "owner": "rynfar",
         "repo": "meridian",
-        "rev": "597a3042cbb7435297cab9960c3dccade3e6bd6f",
+        "rev": "01baa0f4d83738fa5c302149d0e05780f2d47f2b",
         "type": "github"
       },
       "original": {
         "owner": "rynfar",
         "repo": "meridian",
+        "type": "github"
+      }
+    },
+    "meridian-plugin-hermes-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706868,
+        "narHash": "sha256-NZ5jpEEShJPHWhpY/lqU81dkui2CgWf3GhOPKyqNKAM=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-hermes-scrub",
+        "rev": "d3a28e5465fee9eb8ffdde340f4f973fa9d450b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-hermes-scrub",
+        "type": "github"
+      }
+    },
+    "meridian-plugin-opencode-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706886,
+        "narHash": "sha256-OhIYu4aZP+6RvlnDxraXfbh3Fez0QZ9pkaekmHkfBzY=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-opencode-scrub",
+        "rev": "59a1bfce767d1994a4bb6a700373e4c11aef3633",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-opencode-scrub",
+        "type": "github"
+      }
+    },
+    "meridian-plugin-pi-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706871,
+        "narHash": "sha256-S3QdJQvSR3claesMgSPZvVFosuuDeYDgpMwBRR+3zM0=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-pi-scrub",
+        "rev": "65fe302e570044f6f115805d82b619277a8e538f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-pi-scrub",
         "type": "github"
       }
     },
     "mnw": {
       "locked": {
-        "lastModified": 1770419553,
-        "narHash": "sha256-b1XqsH7AtVf2dXmq2iyRr2NC1yG7skY7Z6N2MpWHlK4=",
+        "lastModified": 1780772958,
+        "narHash": "sha256-VKKe8r4pwCGWZ3Yr9CPN129R4S3CKLSrlYqdYz3vKpM=",
         "owner": "Gerg-L",
         "repo": "mnw",
-        "rev": "2aaffa8030d0b262176146adbb6b0e6374ce2957",
+        "rev": "0871dbf63a53610c95db04439ed8ea4d6ec9c160",
         "type": "github"
       },
       "original": {
         "owner": "Gerg-L",
         "repo": "mnw",
-        "type": "github"
-      }
-    },
-    "ndg": {
-      "inputs": {
-        "nixpkgs": [
-          "aytordev-nvim",
-          "nvf",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768214250,
-        "narHash": "sha256-hnBZDQWUxJV3KbtvyGW5BKLO/fAwydrxm5WHCWMQTbw=",
-        "owner": "feel-co",
-        "repo": "ndg",
-        "rev": "a6bd3c1ce2668d096e4fdaaa03ad7f03ba1fbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "feel-co",
-        "ref": "refs/tags/v2.6.0",
-        "repo": "ndg",
         "type": "github"
       }
     },
@@ -275,11 +312,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1784123936,
+        "narHash": "sha256-IOWwQMJhUxcojm0MRvuKs1fKLH727u4+hHeEOPhdUyA=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "a4cf1d10853b0d2be19b9eca35d749e201d70b55",
         "type": "github"
       },
       "original": {
@@ -295,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778999127,
-        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
+        "lastModified": 1783864904,
+        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
+        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
         "type": "github"
       },
       "original": {
@@ -330,11 +367,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -346,32 +383,17 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1784210874,
+        "narHash": "sha256-x8i+HYAulduMlM63oxWJj5tAm+Sc/W756wUzcV5p24w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "59682e0069f0ed0a452e2179a7f4c1f247027b9e",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -393,11 +415,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -426,21 +448,17 @@
     "nvf": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
         "mnw": "mnw",
-        "ndg": "ndg",
         "nixpkgs": [
-          "aytordev-nvim",
           "nixpkgs"
-        ],
-        "systems": "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1772715593,
-        "narHash": "sha256-aTnUeZdJK01p/5od8k4cGuRA5AfADAUmka69KSPjeWY=",
+        "lastModified": 1784320861,
+        "narHash": "sha256-sPUghbl8wMmESus7KvsmHIUEyD2mi13/xu7/u2H5SZU=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "a3123a9ac2ed15ad7b56d2854a9013e3ab9c0af1",
+        "rev": "43fdcbf2e00290479d3f9b97b7f61edd08c4e584",
         "type": "github"
       },
       "original": {
@@ -452,7 +470,7 @@
     "root": {
       "inputs": {
         "aytordev-nvim": "aytordev-nvim",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "home-manager": "home-manager_2",
         "mcp-servers-nix": "mcp-servers-nix",
         "meridian": "meridian",
@@ -463,6 +481,7 @@
         "nixpkgs-darwin": "nixpkgs-darwin",
         "nixpkgs-stable": "nixpkgs-stable",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "nvf": "nvf",
         "secrets": "secrets",
         "sops-nix": "sops-nix_2",
         "yazi-flavors": "yazi-flavors"
@@ -517,11 +536,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {
@@ -546,21 +565,6 @@
       }
     },
     "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -621,11 +625,11 @@
     "yazi-flavors": {
       "flake": false,
       "locked": {
-        "lastModified": 1778937272,
-        "narHash": "sha256-46x4K4dx4rlU108SXhctJOeGlO/W57Pnofb914Sa4vA=",
+        "lastModified": 1782552321,
+        "narHash": "sha256-erZI0H5TxqFu2P917juL5PIB3LC0oJGKPcB1VibJDqo=",
         "owner": "yazi-rs",
         "repo": "flavors",
-        "rev": "54ab389e4deb3d1bc1d8de18d99e825962a55da1",
+        "rev": "4770a3467169bfdb0a3b11601921aaf27c100630",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -69,10 +69,15 @@
       url = "github:natsukium/mcp-servers-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nvf = {
+      url = "github:NotAShelf/nvf";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     aytordev-nvim = {
       url = "github:aytordev/aytordev.nvim";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-parts.follows = "flake-parts";
+      inputs.nvf.follows = "nvf";
     };
     meridian = {
       url = "github:rynfar/meridian";

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -11,8 +11,11 @@
           "root",
           "nixpkgs"
         ],
-        "nvf": "nvf",
-        "systems": "systems_2",
+        "nvf": [
+          "root",
+          "nvf"
+        ],
+        "systems": "systems",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -31,7 +34,11 @@
     },
     "bun2nix": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
+        "flake-parts": [
+          "root",
+          "meridian",
+          "flake-parts"
+        ],
         "import-tree": "import-tree",
         "nixpkgs": [
           "root",
@@ -63,11 +70,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1751685974,
-        "narHash": "sha256-NKw96t+BgHIYzHUjkTK95FqYRVKB8DHpVhefWSz/kTw=",
+        "lastModified": 1777699697,
+        "narHash": "sha256-Eg9b/rq/ECYwNwEXs5i9wHyhxNI0JrYx2srdI2uZMaQ=",
         "ref": "refs/heads/main",
-        "rev": "549f2762aebeff29a2e5ece7a7dc0f955281a1d1",
-        "revCount": 92,
+        "rev": "382052b74656a369c5408822af3f2501e9b1af81",
+        "revCount": 94,
         "type": "git",
         "url": "https://git.lix.systems/lix-project/flake-compat.git"
       },
@@ -80,17 +87,15 @@
       "inputs": {
         "nixpkgs-lib": [
           "root",
-          "aytordev-nvim",
-          "nvf",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -103,6 +108,7 @@
       "inputs": {
         "nixpkgs-lib": [
           "root",
+          "meridian",
           "nixpkgs"
         ]
       },
@@ -120,64 +126,24 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "git-hooks-nix": {
       "inputs": {
         "flake-compat": [],
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -195,6 +161,28 @@
         "owner": "nix-community",
         "repo": "home-manager",
         "rev": "5a75730e6f21ee624cbf86f4915c6e7489c74acc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
+      "inputs": {
+        "nixpkgs": [
+          "root",
+          "meridian",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781642113,
+        "narHash": "sha256-mAR7KTS9rjreTcXCNqfCbN96mnhJO8lDQq1vl7GviBQ=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "df4e0465717a2d34f05b8ccd967275aaf3ceaa01",
         "type": "github"
       },
       "original": {
@@ -226,11 +214,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779201614,
-        "narHash": "sha256-AFcjCGsu40BwdxjFicL4X6i56XrmACAQW9xPUNU9r4Y=",
+        "lastModified": 1784293699,
+        "narHash": "sha256-NU0hTN14YgxSrTDU0ELAF7i5gjsqHxI9AsbS38nAO/4=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "053554b898b3e1d5a3517d0596ed958d2be7b105",
+        "rev": "9537416185661acf10c59cec4886105f60bf2a7e",
         "type": "github"
       },
       "original": {
@@ -242,62 +230,91 @@
     "meridian": {
       "inputs": {
         "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts_2",
+        "home-manager": "home-manager_2",
+        "meridian-plugin-hermes-scrub": "meridian-plugin-hermes-scrub",
+        "meridian-plugin-opencode-scrub": "meridian-plugin-opencode-scrub",
+        "meridian-plugin-pi-scrub": "meridian-plugin-pi-scrub",
         "nixpkgs": [
           "root",
           "nixpkgs"
         ],
-        "systems": "systems_3"
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1778524794,
-        "narHash": "sha256-rr9l+TGqppjpdQih2/nZ46EexkV2UQ1bMUKnNVu2dWg=",
+        "lastModified": 1784314998,
+        "narHash": "sha256-2zwk40gqJkH1ZvtulzbizJ1zXgyRSGc0cPj3XBqbtYo=",
         "owner": "rynfar",
         "repo": "meridian",
-        "rev": "597a3042cbb7435297cab9960c3dccade3e6bd6f",
+        "rev": "01baa0f4d83738fa5c302149d0e05780f2d47f2b",
         "type": "github"
       },
       "original": {
         "owner": "rynfar",
         "repo": "meridian",
+        "type": "github"
+      }
+    },
+    "meridian-plugin-hermes-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706868,
+        "narHash": "sha256-NZ5jpEEShJPHWhpY/lqU81dkui2CgWf3GhOPKyqNKAM=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-hermes-scrub",
+        "rev": "d3a28e5465fee9eb8ffdde340f4f973fa9d450b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-hermes-scrub",
+        "type": "github"
+      }
+    },
+    "meridian-plugin-opencode-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706886,
+        "narHash": "sha256-OhIYu4aZP+6RvlnDxraXfbh3Fez0QZ9pkaekmHkfBzY=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-opencode-scrub",
+        "rev": "59a1bfce767d1994a4bb6a700373e4c11aef3633",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-opencode-scrub",
+        "type": "github"
+      }
+    },
+    "meridian-plugin-pi-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706871,
+        "narHash": "sha256-S3QdJQvSR3claesMgSPZvVFosuuDeYDgpMwBRR+3zM0=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-pi-scrub",
+        "rev": "65fe302e570044f6f115805d82b619277a8e538f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-pi-scrub",
         "type": "github"
       }
     },
     "mnw": {
       "locked": {
-        "lastModified": 1770419553,
-        "narHash": "sha256-b1XqsH7AtVf2dXmq2iyRr2NC1yG7skY7Z6N2MpWHlK4=",
+        "lastModified": 1780772958,
+        "narHash": "sha256-VKKe8r4pwCGWZ3Yr9CPN129R4S3CKLSrlYqdYz3vKpM=",
         "owner": "Gerg-L",
         "repo": "mnw",
-        "rev": "2aaffa8030d0b262176146adbb6b0e6374ce2957",
+        "rev": "0871dbf63a53610c95db04439ed8ea4d6ec9c160",
         "type": "github"
       },
       "original": {
         "owner": "Gerg-L",
         "repo": "mnw",
-        "type": "github"
-      }
-    },
-    "ndg": {
-      "inputs": {
-        "nixpkgs": [
-          "root",
-          "aytordev-nvim",
-          "nvf",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768214250,
-        "narHash": "sha256-hnBZDQWUxJV3KbtvyGW5BKLO/fAwydrxm5WHCWMQTbw=",
-        "owner": "feel-co",
-        "repo": "ndg",
-        "rev": "a6bd3c1ce2668d096e4fdaaa03ad7f03ba1fbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "feel-co",
-        "ref": "refs/tags/v2.6.0",
-        "repo": "ndg",
         "type": "github"
       }
     },
@@ -309,11 +326,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778999127,
-        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
+        "lastModified": 1783864904,
+        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
+        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
         "type": "github"
       },
       "original": {
@@ -324,11 +341,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -338,28 +355,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -372,22 +374,18 @@
     "nvf": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
         "mnw": "mnw",
-        "ndg": "ndg",
         "nixpkgs": [
           "root",
-          "aytordev-nvim",
           "nixpkgs"
-        ],
-        "systems": "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1772715593,
-        "narHash": "sha256-aTnUeZdJK01p/5od8k4cGuRA5AfADAUmka69KSPjeWY=",
+        "lastModified": 1784320861,
+        "narHash": "sha256-sPUghbl8wMmESus7KvsmHIUEyD2mi13/xu7/u2H5SZU=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "a3123a9ac2ed15ad7b56d2854a9013e3ab9c0af1",
+        "rev": "43fdcbf2e00290479d3f9b97b7f61edd08c4e584",
         "type": "github"
       },
       "original": {
@@ -414,7 +412,7 @@
     "root_2": {
       "inputs": {
         "aytordev-nvim": "aytordev-nvim",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "home-manager": [],
         "mcp-servers-nix": "mcp-servers-nix",
         "meridian": "meridian",
@@ -425,6 +423,7 @@
         "nixpkgs-darwin": [],
         "nixpkgs-stable": [],
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "nvf": "nvf",
         "secrets": [],
         "sops-nix": [],
         "yazi-flavors": []
@@ -455,21 +454,6 @@
       }
     },
     "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -536,11 +520,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/libraries/system/common/default.nix
+++ b/libraries/system/common/default.nix
@@ -14,6 +14,9 @@ in {
     config = {
       allowAliases = false;
       allowUnfree = true;
+      permittedInsecurePackages = [
+        "electron-39.8.10" # bitwarden-desktop dependency, pending nixpkgs update
+      ];
     };
   };
 

--- a/libraries/system/common/default.nix
+++ b/libraries/system/common/default.nix
@@ -14,9 +14,6 @@ in {
     config = {
       allowAliases = false;
       allowUnfree = true;
-      permittedInsecurePackages = [
-        "electron-39.8.10" # bitwarden-desktop dependency, pending nixpkgs update
-      ];
     };
   };
 

--- a/modules/darwin/suites/business/default.nix
+++ b/modules/darwin/suites/business/default.nix
@@ -14,6 +14,7 @@ in {
   config = mkIf cfg.enable {
     homebrew = {
       casks = [
+        "bitwarden"
         "obsidian"
         "protonvpn"
       ];

--- a/modules/darwin/suites/development/default.nix
+++ b/modules/darwin/suites/development/default.nix
@@ -1,13 +1,12 @@
 {
   config,
   lib,
+  pkgs,
   ...
-}:
-let
+}: let
   inherit (lib) mkIf;
   cfg = config.aytordev.suites.development;
-in
-{
+in {
   options.aytordev.suites.development = {
     enable = lib.mkEnableOption "common development configuration";
     dockerEnable = lib.mkEnableOption "docker desktop configuration";
@@ -20,16 +19,16 @@ in
     # aytordev.nix.nix-rosetta-builder.enable = true;
 
     homebrew = {
-      casks = [
-        "ghostty"
-        "pencil"
-      ]
-      ++ lib.optionals cfg.dockerEnable [
-        "docker-desktop"
-      ]
-      ++ lib.optionals cfg.podmanEnable [
-        "podman-desktop"
-      ];
+      casks =
+        [
+          "ghostty"
+        ]
+        ++ lib.optionals cfg.dockerEnable [
+          "docker-desktop"
+        ]
+        ++ lib.optionals cfg.podmanEnable [
+          "podman-desktop"
+        ];
 
       masApps = mkIf config.aytordev.tools.homebrew.masEnable {
         # TODO: Add Mac App Store apps
@@ -40,6 +39,8 @@ in
       ollama.enable = lib.mkDefault cfg.aiEnable;
       litellm.enable = lib.mkDefault cfg.aiEnable;
     };
+
+    environment.systemPackages = [pkgs.aytordev.pencil-dev];
 
     nix.settings = {
       keep-derivations = true;

--- a/modules/home/programs/desktop/security/bitwarden/default.nix
+++ b/modules/home/programs/desktop/security/bitwarden/default.nix
@@ -16,6 +16,17 @@ in {
       description = "The Bitwarden package to install.";
     };
 
+    installPackage = lib.mkOption {
+      type = lib.types.bool;
+      default = !pkgs.stdenv.hostPlatform.isDarwin;
+      defaultText = lib.literalExpression "!pkgs.stdenv.hostPlatform.isDarwin";
+      description = ''
+        Install the Bitwarden package via Home Manager.
+        On Darwin, the desktop app is managed as a Homebrew cask to avoid
+        nixpkgs Electron/native-linker build failures.
+      '';
+    };
+
     settings = lib.mkOption {
       type = lib.types.attrs;
       default = {};
@@ -88,7 +99,10 @@ in {
       };
 
       timeoutAction = lib.mkOption {
-        type = lib.types.enum ["lock" "logout"];
+        type = lib.types.enum [
+          "lock"
+          "logout"
+        ];
         default = "lock";
         description = ''
           Action to take when vault times out.
@@ -98,12 +112,13 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [cfg.package];
+    home.packages = lib.optional cfg.installPackage cfg.package;
 
     # Create Bitwarden config directory and settings file if settings are provided
     xdg.configFile = lib.mkIf (cfg.settings != {}) {
       "Bitwarden/data.json" = {
-        text = builtins.toJSON (cfg.settings
+        text = builtins.toJSON (
+          cfg.settings
           // {
             # Merge user settings with our module options
             inherit (cfg) enableBrowserIntegration;
@@ -114,12 +129,13 @@ in {
             biometricRequirePasswordOnStart = cfg.biometricUnlock.requirePasswordOnStart;
             vaultTimeout = cfg.vault.timeout;
             vaultTimeoutAction = cfg.vault.timeoutAction;
-          });
+          }
+        );
       };
     };
 
     # Setup launch agent for macOS to start at login if enabled
-    launchd.agents = lib.mkIf (pkgs.stdenv.isDarwin && cfg.enableSystemStartup) {
+    launchd.agents = lib.mkIf (pkgs.stdenv.isDarwin && cfg.enableSystemStartup && cfg.installPackage) {
       bitwarden = {
         enable = true;
         config = {

--- a/modules/home/programs/terminal/tools/fastfetch/default.nix
+++ b/modules/home/programs/terminal/tools/fastfetch/default.nix
@@ -10,10 +10,9 @@ in {
     enable = mkEnableOption "fastfetch";
   };
   config = mkIf config.aytordev.programs.terminal.tools.fastfetch.enable {
-    home.packages = with pkgs; [fastfetchMinimal];
     programs.fastfetch = {
       enable = true;
-      package = pkgs.fastfetchMinimal;
+      package = pkgs.fastfetch;
       settings = {
         "$schema" = "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json";
         logo = {

--- a/modules/home/programs/terminal/tools/fzf/default.nix
+++ b/modules/home/programs/terminal/tools/fzf/default.nix
@@ -4,7 +4,13 @@
   pkgs,
   ...
 }: let
-  inherit (lib) mkIf mkEnableOption mkOption types;
+  inherit
+    (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    ;
   cfg = config.aytordev.programs.terminal.tools.fzf;
   defaultOptions = [
     "--layout=reverse"
@@ -78,6 +84,7 @@ in {
         enable = true;
         inherit (cfg) defaultCommand;
         defaultOptions = defaultOptions ++ cfg.extraOptions;
+        historyWidget.command = "";
       };
       zsh = {
         plugins = [

--- a/modules/home/programs/terminal/tools/gemini-cli/default.nix
+++ b/modules/home/programs/terminal/tools/gemini-cli/default.nix
@@ -22,7 +22,7 @@ in {
       source = lib.getExe pkgs.ripgrep;
     };
 
-    programs.gemini-cli = {
+    programs.antigravity-cli = {
       enable = true;
 
       settings = {

--- a/modules/home/programs/terminal/tools/git/default.nix
+++ b/modules/home/programs/terminal/tools/git/default.nix
@@ -119,7 +119,10 @@ in {
               };
             };
             difftastic = {
-              git.diffToolMode = true;
+              git = {
+                enable = true;
+                mode = "both";
+              };
               options = {
                 background = "dark";
                 display = "inline";

--- a/modules/home/programs/terminal/tools/yazi/default.nix
+++ b/modules/home/programs/terminal/tools/yazi/default.nix
@@ -23,6 +23,8 @@ in {
         pkgs.atool
         pkgs.exiftool
         pkgs.mediainfo
+      ]
+      ++ lib.optionals (!pkgs.stdenv.hostPlatform.isDarwin) [
         pkgs.unar
       ]
       ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [

--- a/modules/home/programs/terminal/tools/yazi/settings/opener.nix
+++ b/modules/home/programs/terminal/tools/yazi/settings/opener.nix
@@ -44,18 +44,21 @@
         for = "unix";
       }
     ];
-    extract = [
-      {
-        desc = "Extract with atool";
-        run = "${lib.getExe pkgs.atool} --extract --each --subdir --quiet -- \"$@\"";
-        block = true;
-      }
-      {
-        run = "${lib.getExe pkgs.unar} \"$1\"";
-        desc = "Extract here";
-        for = "unix";
-      }
-    ];
+    extract =
+      [
+        {
+          desc = "Extract with atool";
+          run = "${lib.getExe pkgs.atool} --extract --each --subdir --quiet -- \"$@\"";
+          block = true;
+        }
+      ]
+      ++ lib.optionals (!pkgs.stdenv.hostPlatform.isDarwin) [
+        {
+          run = "${lib.getExe pkgs.unar} \"$1\"";
+          desc = "Extract here";
+          for = "unix";
+        }
+      ];
     play = [
       {
         run = "${lib.getExe pkgs.mediainfo} \"$1\"; echo \"Press enter to exit\"; read _";

--- a/overlays/protonmail-bridge/install_darwin.go
+++ b/overlays/protonmail-bridge/install_darwin.go
@@ -46,7 +46,7 @@ func NewInstaller(*versioner.Versioner) *InstallerDarwin {
 }
 
 // InstallUpdate is intentionally a no-op. See package comment.
-func (i *InstallerDarwin) InstallUpdate(_ *semver.Version, _ io.Reader) error {
+func (i *InstallerDarwin) InstallUpdate(_ *semver.Version, _ io.Reader, _ bool) error {
 	return nil
 }
 

--- a/packages/pencil-dev/package.nix
+++ b/packages/pencil-dev/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  ...
+}:
+stdenvNoCC.mkDerivation {
+  pname = "pencil-dev";
+  version = "1.1.63";
+
+  src = fetchurl {
+    url = "https://www.pencil.dev/download/Pencil-mac-arm64.dmg";
+    hash = "sha256-VppyV3l8Pc4dpWxv3m9+JYnvjAwhx2NCrBZkGgQPig0=";
+  };
+
+  nativeBuildInputs = [undmg];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/Applications"
+    cp -r "Pencil.app" "$out/Applications/"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Design on canvas. Land in code.";
+    homepage = "https://pencil.dev";
+    platforms = ["aarch64-darwin"];
+    license = lib.licenses.unfree;
+  };
+}


### PR DESCRIPTION
# Description

Consolidate the pending flake updates and platform-specific configuration fixes.

## Changes

- Update flake inputs and move the Node development shell to Node 26.
- Add the Pencil development package and align the Darwin development suite.
- Manage the Bitwarden desktop app with Homebrew on Darwin to avoid the insecure Electron dependency.
- Align terminal tool modules with current Home Manager APIs and Darwin package availability.
- Disable the ProtonMail Bridge self-updater with the current updater interface.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Validation

- `nix flake check --all-systems --extra-experimental-features "nix-command flakes" --show-trace`
- `nix build .#checks.aarch64-darwin.treefmt --no-link --print-build-logs`
- `git diff --check`

The repository's `just fmt-check` helper remains incompatible with the installed treefmt CLI because it passes the unsupported `--check` flag; the CI workflow uses the treefmt derivation validated above.