### PR TITLE
fix(ci): restore format checks and Node 24

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Check Nix flake inputs
-        uses: DeterminateSystems/flake-checker-action@v12
+        uses: DeterminateSystems/flake-checker-action@v13
       - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |

--- a/Justfile
+++ b/Justfile
@@ -31,7 +31,7 @@ fmt path=".":
 # Usage: just fmt-check [path]  # Check files or directories (default: .)
 [group('nix')]
 fmt-check path=".":
-    nix run .#formatter.aarch64-darwin -- --check "{{path}}"
+    nix run .#formatter.aarch64-darwin -- --ci "{{path}}"
 
 # Garbage collection
 [group('nix')]


### PR DESCRIPTION
# Description

Resolve the two CI maintenance issues identified after PR #177.

## Changes

- Use treefmt's supported `--ci` mode in `just fmt-check`, preserving the no-change check behavior.
- Upgrade `DeterminateSystems/flake-checker-action` from v12 to v13, which runs on Node 24.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Validation

- `just fmt-check`
- `nix flake check --all-systems --extra-experimental-features "nix-command flakes" --show-trace`
- `nix run nixpkgs#actionlint -- .github/workflows/check.yml`
- `git diff --check`